### PR TITLE
Development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0.61"
 chrono = "0.4.38"
 # FIX: Enable the "path" feature for tilde expansion
 shellexpand = { version = "3.1.1", features = ["path"] }
+similar = "2.6"
 
 # CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ chrono = "0.4.38"
 # FIX: Enable the "path" feature for tilde expansion
 shellexpand = { version = "3.1.1", features = ["path"] }
 
+# CLI argument parsing
+clap = { version = "4.5", features = ["derive"] }
+
 [dev-dependencies]
 # For integration tests
 tempfile = "3.10.1"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ A terminal-based user interface (TUI) application for managing dotfiles using sy
 - 📁 **Profile-based Management** - Organize different sets of dotfiles for different environments (work, personal, etc.)
 - 🔗 **Symlink Creation** - Automatically create symlinks from your dotfile repository to target locations
 - 💾 **Automatic Backups** - Backs up existing files before replacing them with symlinks
-- 🔍 **Dry Run Mode** - Preview changes before applying them
+- 🔍 **Dry Run Mode** - Preview changes before applying them (TUI and CLI)
 - 🎨 **Interactive TUI** - Easy-to-use terminal interface for profile selection and sync operations
+- ⚙️ **CLI Arguments** - Headless mode for automation, custom config paths, and direct profile selection
 - ⚡ **Background Operations** - Non-blocking UI with background sync operations
 - 🪟 **Cross-platform** - Supports both Unix-like systems and Windows
 
@@ -74,7 +75,51 @@ links = [
 
 ## Usage
 
-### Key Bindings
+### Interactive TUI Mode
+
+By default, running the application without arguments launches the interactive TUI:
+
+```bash
+# Launch TUI with default config.toml
+tui-dotfile-manager
+
+# Launch TUI with custom config
+tui-dotfile-manager --config ~/.config/dotfiles/config.toml
+```
+
+### CLI Arguments (Headless Mode)
+
+The application supports command-line arguments for automation and scripting:
+
+```bash
+# List available profiles
+tui-dotfile-manager --list-profiles
+tui-dotfile-manager -l
+
+# Sync a specific profile (headless mode)
+tui-dotfile-manager --profile personal
+tui-dotfile-manager -p work
+
+# Perform a dry run (preview changes without applying)
+tui-dotfile-manager --profile work --dry-run
+tui-dotfile-manager -p personal -d
+
+# Use a custom config file
+tui-dotfile-manager --config ~/.dotfiles/work.toml --profile work
+
+# Combine options
+tui-dotfile-manager -c ~/dotfiles/config.toml -p personal --dry-run
+```
+
+**Available Options:**
+- `-c, --config <PATH>` - Path to configuration file (default: `config.toml`)
+- `-p, --profile <NAME>` - Profile to sync (skips TUI if provided)
+- `-d, --dry-run` - Perform a dry run without making changes
+- `-l, --list-profiles` - List available profiles and exit
+- `-h, --help` - Print help information
+- `-V, --version` - Print version information
+
+### TUI Key Bindings
 
 Once the TUI is running:
 
@@ -86,12 +131,49 @@ Once the TUI is running:
 
 ### Workflow
 
+#### Interactive (TUI) Workflow
 1. **Create your config** - Set up `config.toml` with your profiles
 2. **Launch the TUI** - Run the application
 3. **Select a profile** - Use arrow keys or `j/k` to navigate
 4. **Preview changes** - Press `d` for a dry run
 5. **Apply changes** - Press `s` to sync the selected profile
 6. **Review logs** - Check the log panel for operation details
+
+#### Headless (CLI) Workflow
+1. **Create your config** - Set up configuration file
+2. **List profiles** - Run `tui-dotfile-manager --list-profiles` to see available profiles
+3. **Preview changes** - Run `tui-dotfile-manager -p <profile> --dry-run`
+4. **Apply changes** - Run `tui-dotfile-manager -p <profile>`
+
+### Use Cases
+
+**Automation & Scripting:**
+```bash
+#!/bin/bash
+# Auto-sync work profile on login
+tui-dotfile-manager -c ~/.dotfiles/config.toml -p work
+```
+
+**Multiple Configurations:**
+```bash
+# Switch between different dotfile repos
+tui-dotfile-manager -c ~/.dotfiles/personal.toml -p default
+tui-dotfile-manager -c ~/.dotfiles/work.toml -p corporate
+```
+
+**CI/CD Integration:**
+```bash
+# Test dotfile sync in GitHub Actions
+tui-dotfile-manager --config ./test-config.toml --profile test --dry-run
+```
+
+**Quick Profile Switching (Shell Aliases):**
+```bash
+# Add to your .bashrc or .zshrc
+alias dots-work='tui-dotfile-manager -p work'
+alias dots-personal='tui-dotfile-manager -p personal'
+alias dots-list='tui-dotfile-manager -l'
+```
 
 ## How It Works
 
@@ -165,6 +247,7 @@ cargo fmt
 - **anyhow** & **thiserror** - Error handling
 - **chrono** - Timestamp generation
 - **shellexpand** - Path expansion (`~` support)
+- **clap** - Command-line argument parsing
 
 ## Safety & Behavior
 
@@ -176,13 +259,11 @@ cargo fmt
 
 ## Limitations
 
-- Currently looks for `config.toml` in the current directory only
 - No built-in rollback mechanism (backups must be restored manually)
 - No diff preview for file contents
 
 ## Future Enhancements
 
-- [ ] CLI arguments for config path and profile selection
 - [ ] Restore from backup functionality in TUI
 - [ ] Configuration reload without restart
 - [ ] Progress indicators for large sync operations

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A terminal-based user interface (TUI) application for managing dotfiles using sy
 - 🔗 **Symlink Creation** - Automatically create symlinks from your dotfile repository to target locations
 - 💾 **Automatic Backups** - Backs up existing files before replacing them with symlinks
 - 🔄 **Restore from Backups** - Browse, preview, and restore backed-up files directly from the TUI
+- 🔃 **Configuration Reload** - Reload config.toml without restarting the application (press `R`)
 - 🔍 **Dry Run Mode** - Preview changes before applying them (TUI and CLI)
 - 🎨 **Interactive TUI** - Easy-to-use terminal interface for profile selection and sync operations
 - ⚙️ **CLI Arguments** - Headless mode for automation, custom config paths, and direct profile selection
@@ -129,6 +130,7 @@ Once the TUI is running:
 - **`k` / `↑`** - Select previous profile
 - **`s` / `Enter`** - Sync the selected profile (creates symlinks)
 - **`d`** - Dry run (preview changes without applying)
+- **`R`** - Reload configuration file
 - **`r`** - Enter restore mode
 - **`q` / `Esc`** - Quit the application
 
@@ -149,6 +151,7 @@ Once the TUI is running:
 4. **Preview changes** - Press `d` for a dry run
 5. **Apply changes** - Press `s` to sync the selected profile
 6. **Review logs** - Check the log panel for operation details
+7. **Reload config** - Press `R` to reload config.toml after making changes (no restart needed)
 
 #### Restore Workflow (TUI)
 1. **Enter restore mode** - Press `r` from the main view
@@ -206,6 +209,23 @@ alias dots-list='tui-dotfile-manager -l'
    - If it's a regular file/directory, back it up with a timestamp
 4. **Symlink Creation**: Creates symlinks from your repo to target locations
 5. **Logging**: All operations are logged in the TUI
+
+### Configuration Reload
+1. **Edit Config**: Modify `config.toml` while the application is running
+   - Add/remove profiles
+   - Update profile links
+   - Change settings paths
+2. **Trigger Reload**: Press `R` in the TUI (sync mode only)
+3. **Validation**: The new configuration is parsed and validated
+4. **Update UI**: Profile list updates immediately
+5. **Smart Selection**: 
+   - If the currently selected profile still exists, it remains selected
+   - If the selected profile was removed, switches to the first available profile
+   - If all profiles are removed, no profile is selected
+6. **Error Handling**: Invalid configurations are rejected gracefully
+   - Shows error message in the log panel
+   - Maintains the previous valid configuration
+7. **Operation Blocking**: Reload is prevented during active sync/restore operations
 
 ### Restore Operation
 1. **Backup Discovery**: Scans the backup directory for backed-up files
@@ -298,7 +318,7 @@ cargo fmt
 ## Future Enhancements
 
 - [x] Restore from backup functionality in TUI ✅ **Completed**
-- [ ] Configuration reload without restart
+- [x] Configuration reload without restart ✅ **Completed**
 - [ ] Progress indicators for large sync operations
 - [ ] Diff preview before syncing
 - [ ] Backup compression

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A terminal-based user interface (TUI) application for managing dotfiles using sy
 - 📁 **Profile-based Management** - Organize different sets of dotfiles for different environments (work, personal, etc.)
 - 🔗 **Symlink Creation** - Automatically create symlinks from your dotfile repository to target locations
 - 💾 **Automatic Backups** - Backs up existing files before replacing them with symlinks
+- 🔄 **Restore from Backups** - Browse, preview, and restore backed-up files directly from the TUI
 - 🔍 **Dry Run Mode** - Preview changes before applying them (TUI and CLI)
 - 🎨 **Interactive TUI** - Easy-to-use terminal interface for profile selection and sync operations
 - ⚙️ **CLI Arguments** - Headless mode for automation, custom config paths, and direct profile selection
@@ -123,11 +124,21 @@ tui-dotfile-manager -c ~/dotfiles/config.toml -p personal --dry-run
 
 Once the TUI is running:
 
+#### Sync Mode (default)
 - **`j` / `↓`** - Select next profile
 - **`k` / `↑`** - Select previous profile
 - **`s` / `Enter`** - Sync the selected profile (creates symlinks)
 - **`d`** - Dry run (preview changes without applying)
+- **`r`** - Enter restore mode
 - **`q` / `Esc`** - Quit the application
+
+#### Restore Mode
+- **`j` / `↓`** - Select next backup
+- **`k` / `↑`** - Select previous backup
+- **`r` / `Enter`** - Restore the selected backup
+- **`d`** - Dry run restore (preview without applying)
+- **`Delete`** - Delete the selected backup
+- **`b` / `Esc`** - Back to sync mode
 
 ### Workflow
 
@@ -138,6 +149,15 @@ Once the TUI is running:
 4. **Preview changes** - Press `d` for a dry run
 5. **Apply changes** - Press `s` to sync the selected profile
 6. **Review logs** - Check the log panel for operation details
+
+#### Restore Workflow (TUI)
+1. **Enter restore mode** - Press `r` from the main view
+2. **Browse backups** - Use `j/k` to navigate the backup list
+3. **Preview backup** - View metadata and content preview in the preview panel
+4. **Dry run restore** - Press `d` to preview the restore operation
+5. **Restore backup** - Press `r` or `Enter` to restore the selected backup
+6. **Delete backups** - Press `Delete` to remove old backups
+7. **Return to sync mode** - Press `b` or `Esc`
 
 #### Headless (CLI) Workflow
 1. **Create your config** - Set up configuration file
@@ -177,6 +197,7 @@ alias dots-list='tui-dotfile-manager -l'
 
 ## How It Works
 
+### Sync Operation
 1. **Profile Selection**: Choose which set of dotfiles to sync
 2. **Path Resolution**: Expands `~` and resolves relative paths
 3. **Backup Creation**: If a file exists at the target location:
@@ -185,6 +206,17 @@ alias dots-list='tui-dotfile-manager -l'
    - If it's a regular file/directory, back it up with a timestamp
 4. **Symlink Creation**: Creates symlinks from your repo to target locations
 5. **Logging**: All operations are logged in the TUI
+
+### Restore Operation
+1. **Backup Discovery**: Scans the backup directory for backed-up files
+2. **Backup Parsing**: Extracts original filename and timestamp from backup filenames
+3. **Target Resolution**: Matches backups to their original target locations from the config
+4. **Preview**: Shows backup metadata, size, timestamp, and content preview
+5. **Restoration**:
+   - Removes or backs up the current file at the target location
+   - Copies the backup file to the target location
+   - Removes the backup file from the backup directory
+6. **Logging**: All operations are logged in the TUI
 
 ### Backup Format
 
@@ -253,21 +285,24 @@ cargo fmt
 
 - **TOCTOU Protection**: Uses metadata checks to avoid race conditions
 - **Backup Safety**: High-precision timestamps (microseconds) prevent overwrites
+- **Backup Before Restore**: Current files are backed up before restoration to prevent data loss
 - **Validation**: Configuration is validated on load
 - **Error Handling**: Graceful error handling with detailed messages
 - **Memory Management**: Log rotation prevents unbounded memory growth
 
 ## Limitations
 
-- No built-in rollback mechanism (backups must be restored manually)
 - No diff preview for file contents
+- Backups are stored locally (no remote backup support)
 
 ## Future Enhancements
 
-- [ ] Restore from backup functionality in TUI
+- [x] Restore from backup functionality in TUI ✅ **Completed**
 - [ ] Configuration reload without restart
 - [ ] Progress indicators for large sync operations
 - [ ] Diff preview before syncing
+- [ ] Backup compression
+- [ ] Remote backup storage
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A terminal-based user interface (TUI) application for managing dotfiles using sy
 - 💾 **Automatic Backups** - Backs up existing files before replacing them with symlinks
 - 🔄 **Restore from Backups** - Browse, preview, and restore backed-up files directly from the TUI
 - 🔍 **Dry Run Mode** - Preview changes before applying them (TUI and CLI)
+- 📊 **Diff Preview** - View file content differences before syncing (NEW!)
 - 🎨 **Interactive TUI** - Easy-to-use terminal interface for profile selection and sync operations
 - ⚙️ **CLI Arguments** - Headless mode for automation, custom config paths, and direct profile selection
 - ⚡ **Background Operations** - Non-blocking UI with background sync operations
@@ -129,8 +130,16 @@ Once the TUI is running:
 - **`k` / `↑`** - Select previous profile
 - **`s` / `Enter`** - Sync the selected profile (creates symlinks)
 - **`d`** - Dry run (preview changes without applying)
+- **`p`** - Diff preview (view file content differences)
 - **`r`** - Enter restore mode
 - **`q` / `Esc`** - Quit the application
+
+#### Diff Preview Mode
+- **`j` / `↓`** - Scroll down in the diff view
+- **`k` / `↑`** - Scroll up in the diff view
+- **`n`** - Navigate to next file diff
+- **`N`** - Navigate to previous file diff
+- **`q` / `Esc`** - Exit diff preview mode and return to sync mode
 
 #### Restore Mode
 - **`j` / `↓`** - Select next backup
@@ -146,9 +155,21 @@ Once the TUI is running:
 1. **Create your config** - Set up `config.toml` with your profiles
 2. **Launch the TUI** - Run the application
 3. **Select a profile** - Use arrow keys or `j/k` to navigate
-4. **Preview changes** - Press `d` for a dry run
+4. **Preview changes** - Press `d` for a dry run or `p` for diff preview
 5. **Apply changes** - Press `s` to sync the selected profile
 6. **Review logs** - Check the log panel for operation details
+
+#### Diff Preview Workflow (TUI)
+1. **Select a profile** - Navigate to the profile you want to preview
+2. **Enter diff mode** - Press `p` to generate and view diffs
+3. **Review diffs** - See color-coded differences:
+   - Green lines (+) will be added from your dotfiles
+   - Red lines (-) will be removed from existing files
+   - Gray lines are unchanged context
+4. **Navigate** - Use `n`/`N` to switch between different file diffs
+5. **Scroll** - Use `j`/`k` to scroll through long diffs
+6. **Exit** - Press `q` or `Esc` to return to sync mode
+7. **Sync if satisfied** - Return to sync mode and press `s` to apply changes
 
 #### Restore Workflow (TUI)
 1. **Enter restore mode** - Press `r` from the main view
@@ -206,6 +227,20 @@ alias dots-list='tui-dotfile-manager -l'
    - If it's a regular file/directory, back it up with a timestamp
 4. **Symlink Creation**: Creates symlinks from your repo to target locations
 5. **Logging**: All operations are logged in the TUI
+
+### Diff Preview Operation
+1. **Diff Generation**: For each file in the selected profile:
+   - Compares the source file in your dotfiles repo with the target file (if it exists)
+   - Detects file type (text, binary, symlink, new file)
+2. **Display**: Shows color-coded differences:
+   - **Green (+)**: Lines that will be added from your dotfiles
+   - **Red (-)**: Lines that will be removed from the existing file
+   - **Gray**: Context lines (unchanged)
+3. **Special Cases**:
+   - **New files**: Shows the entire content that will be created
+   - **Binary files**: Shows a message indicating binary content (no diff)
+   - **Existing symlinks**: Shows message if already correctly linked
+   - **Errors**: Displays error messages for unreadable files
 
 ### Restore Operation
 1. **Backup Discovery**: Scans the backup directory for backed-up files
@@ -280,6 +315,7 @@ cargo fmt
 - **chrono** - Timestamp generation
 - **shellexpand** - Path expansion (`~` support)
 - **clap** - Command-line argument parsing
+- **similar** - Text diff generation
 
 ## Safety & Behavior
 
@@ -292,15 +328,14 @@ cargo fmt
 
 ## Limitations
 
-- No diff preview for file contents
 - Backups are stored locally (no remote backup support)
 
 ## Future Enhancements
 
 - [x] Restore from backup functionality in TUI ✅ **Completed**
+- [x] Diff preview before syncing ✅ **Completed**
 - [ ] Configuration reload without restart
 - [ ] Progress indicators for large sync operations
-- [ ] Diff preview before syncing
 - [ ] Backup compression
 - [ ] Remote backup storage
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -6,13 +6,13 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// The root configuration struct, mapping to the TOML file.
-/// 
+///
 /// # Example TOML
 /// ```toml
 /// [settings]
 /// repo_dir = "dotfiles"
 /// backup_dir = "~/.dotfile_backups"
-/// 
+///
 /// [profiles.personal]
 /// links = [
 ///   { source = ".bashrc", target = "~/.bashrc" },
@@ -31,7 +31,7 @@ impl Config {
         if self.profiles.is_empty() {
             return Err("Configuration must contain at least one profile".to_string());
         }
-        
+
         for (name, profile) in &self.profiles {
             if name.is_empty() {
                 return Err("Profile names cannot be empty".to_string());
@@ -40,13 +40,13 @@ impl Config {
                 return Err(format!("Profile '{}' has no links defined", name));
             }
         }
-        
+
         Ok(())
     }
 }
 
 /// The [settings] section of the config.
-/// 
+///
 /// Contains global settings for the dotfile manager including
 /// the repository directory and backup location.
 #[derive(Debug, Deserialize, Clone)]
@@ -58,7 +58,7 @@ pub struct Settings {
 }
 
 /// A single profile, e.g., [profiles.work]
-/// 
+///
 /// A profile represents a collection of symlink operations that can be
 /// executed together. Useful for maintaining different dotfile sets for
 /// different environments (work, personal, etc.).
@@ -69,7 +69,7 @@ pub struct Profile {
 }
 
 /// A single link task within a profile.
-/// 
+///
 /// Represents a symlink operation from a source file in the repository
 /// to a target location on the filesystem.
 #[derive(Debug, Deserialize, Clone)]

--- a/src/core/diff.rs
+++ b/src/core/diff.rs
@@ -1,0 +1,347 @@
+// Author: Jacques Murray
+//! Diff generation and preview logic for comparing dotfiles.
+
+use similar::{ChangeTag, TextDiff};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Represents the result of comparing a source and target file.
+#[derive(Debug, Clone)]
+pub enum DiffResult {
+    /// No diff needed - already a correct symlink
+    NoDiff {
+        path: PathBuf,
+        reason: String,
+    },
+    /// Text file diff with unified diff output
+    FileDiff {
+        source: PathBuf,
+        target: PathBuf,
+        diff_lines: Vec<DiffLine>,
+    },
+    /// New file will be created (target doesn't exist)
+    NewFile {
+        source: PathBuf,
+        target: PathBuf,
+        content_preview: Vec<String>,
+    },
+    /// Binary files cannot be diffed
+    BinaryFile {
+        source: PathBuf,
+        target: PathBuf,
+    },
+    /// Error reading files
+    Error {
+        source: PathBuf,
+        target: PathBuf,
+        error: String,
+    },
+}
+
+/// Represents a single line in a diff with its change type.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiffLine {
+    pub tag: DiffLineTag,
+    pub content: String,
+}
+
+/// The type of change for a diff line.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DiffLineTag {
+    /// Line exists in both files (context)
+    Equal,
+    /// Line removed from target (only in target)
+    Delete,
+    /// Line added from source (only in source)
+    Insert,
+}
+
+impl DiffResult {
+    /// Gets the target path for this diff result.
+    pub fn target_path(&self) -> &Path {
+        match self {
+            DiffResult::NoDiff { path, .. } => path,
+            DiffResult::FileDiff { target, .. } => target,
+            DiffResult::NewFile { target, .. } => target,
+            DiffResult::BinaryFile { target, .. } => target,
+            DiffResult::Error { target, .. } => target,
+        }
+    }
+
+    /// Returns a summary description of the diff result.
+    pub fn summary(&self) -> String {
+        match self {
+            DiffResult::NoDiff { reason, .. } => reason.clone(),
+            DiffResult::FileDiff { diff_lines, .. } => {
+                let additions = diff_lines
+                    .iter()
+                    .filter(|l| l.tag == DiffLineTag::Insert)
+                    .count();
+                let deletions = diff_lines
+                    .iter()
+                    .filter(|l| l.tag == DiffLineTag::Delete)
+                    .count();
+                format!("+{} -{} lines", additions, deletions)
+            }
+            DiffResult::NewFile { content_preview, .. } => {
+                format!("New file ({} lines)", content_preview.len())
+            }
+            DiffResult::BinaryFile { .. } => "Binary file".to_string(),
+            DiffResult::Error { error, .. } => format!("Error: {}", error),
+        }
+    }
+}
+
+/// Generates a diff between source and target files.
+///
+/// # Arguments
+/// * `source` - Path to the source file in the dotfiles repository
+/// * `target` - Path to the target file on the filesystem
+///
+/// # Returns
+/// A DiffResult describing the differences between the files
+pub fn generate_diff(source: &Path, target: &Path) -> DiffResult {
+    // Check if target exists
+    if !target.exists() {
+        // Target doesn't exist - this will be a new file
+        return match read_text_file(source) {
+            Ok(content) => {
+                let lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+                DiffResult::NewFile {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                    content_preview: lines,
+                }
+            }
+            Err(e) => {
+                // Might be a binary file
+                if is_binary_file(source) {
+                    DiffResult::BinaryFile {
+                        source: source.to_path_buf(),
+                        target: target.to_path_buf(),
+                    }
+                } else {
+                    DiffResult::Error {
+                        source: source.to_path_buf(),
+                        target: target.to_path_buf(),
+                        error: format!("Failed to read source: {}", e),
+                    }
+                }
+            }
+        };
+    }
+
+    // Check if target is a symlink pointing to source
+    if let Ok(link) = fs::read_link(target) {
+        if link == source {
+            return DiffResult::NoDiff {
+                path: target.to_path_buf(),
+                reason: format!("Already linked to {}", source.display()),
+            };
+        }
+    }
+
+    // Read both files
+    let source_content = match read_text_file(source) {
+        Ok(c) => c,
+        Err(e) => {
+            // Check if binary
+            if is_binary_file(source) {
+                return DiffResult::BinaryFile {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                };
+            }
+            return DiffResult::Error {
+                source: source.to_path_buf(),
+                target: target.to_path_buf(),
+                error: format!("Failed to read source: {}", e),
+            };
+        }
+    };
+
+    let target_content = match read_text_file(target) {
+        Ok(c) => c,
+        Err(e) => {
+            // Check if binary
+            if is_binary_file(target) {
+                return DiffResult::BinaryFile {
+                    source: source.to_path_buf(),
+                    target: target.to_path_buf(),
+                };
+            }
+            return DiffResult::Error {
+                source: source.to_path_buf(),
+                target: target.to_path_buf(),
+                error: format!("Failed to read target: {}", e),
+            };
+        }
+    };
+
+    // Generate diff using similar crate
+    let diff = TextDiff::from_lines(&target_content, &source_content);
+
+    let mut diff_lines = Vec::new();
+
+    for change in diff.iter_all_changes() {
+        let tag = match change.tag() {
+            ChangeTag::Equal => DiffLineTag::Equal,
+            ChangeTag::Delete => DiffLineTag::Delete,
+            ChangeTag::Insert => DiffLineTag::Insert,
+        };
+
+        diff_lines.push(DiffLine {
+            tag,
+            content: change.to_string().trim_end().to_string(),
+        });
+    }
+
+    DiffResult::FileDiff {
+        source: source.to_path_buf(),
+        target: target.to_path_buf(),
+        diff_lines,
+    }
+}
+
+/// Attempts to read a file as UTF-8 text.
+fn read_text_file(path: &Path) -> io::Result<String> {
+    fs::read_to_string(path)
+}
+
+/// Checks if a file appears to be binary by looking for null bytes.
+fn is_binary_file(path: &Path) -> bool {
+    if let Ok(bytes) = fs::read(path) {
+        // Check first 8KB for null bytes
+        let check_size = bytes.len().min(8192);
+        bytes[..check_size].contains(&0)
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_diff_new_file() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source.txt");
+        let target = temp.path().join("target.txt");
+
+        fs::write(&source, "line1\nline2\n").unwrap();
+
+        let result = generate_diff(&source, &target);
+
+        match result {
+            DiffResult::NewFile {
+                content_preview, ..
+            } => {
+                assert_eq!(content_preview.len(), 2);
+                assert_eq!(content_preview[0], "line1");
+            }
+            _ => panic!("Expected NewFile result"),
+        }
+    }
+
+    #[test]
+    fn test_diff_already_linked() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source.txt");
+        let target = temp.path().join("target.txt");
+
+        fs::write(&source, "content").unwrap();
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&source, &target).unwrap();
+
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&source, &target).unwrap();
+
+        let result = generate_diff(&source, &target);
+
+        match result {
+            DiffResult::NoDiff { reason, .. } => {
+                assert!(reason.contains("Already linked"));
+            }
+            _ => panic!("Expected NoDiff result"),
+        }
+    }
+
+    #[test]
+    fn test_diff_text_files() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source.txt");
+        let target = temp.path().join("target.txt");
+
+        fs::write(&source, "line1\nline2\nline3\n").unwrap();
+        fs::write(&target, "line1\nold_line\nline3\n").unwrap();
+
+        let result = generate_diff(&source, &target);
+
+        match result {
+            DiffResult::FileDiff { diff_lines, .. } => {
+                let inserts = diff_lines
+                    .iter()
+                    .filter(|l| l.tag == DiffLineTag::Insert)
+                    .count();
+                let deletes = diff_lines
+                    .iter()
+                    .filter(|l| l.tag == DiffLineTag::Delete)
+                    .count();
+
+                assert!(inserts > 0);
+                assert!(deletes > 0);
+            }
+            _ => panic!("Expected FileDiff result"),
+        }
+    }
+
+    #[test]
+    fn test_binary_file() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source.bin");
+        let target = temp.path().join("target.bin");
+
+        // Write binary data (with null bytes)
+        let mut file = fs::File::create(&source).unwrap();
+        file.write_all(&[0u8, 1, 2, 3, 0, 255]).unwrap();
+
+        let mut file = fs::File::create(&target).unwrap();
+        file.write_all(&[0u8, 5, 6, 7, 0, 255]).unwrap();
+
+        let result = generate_diff(&source, &target);
+
+        match result {
+            DiffResult::BinaryFile { .. } => {
+                // Expected
+            }
+            _ => panic!("Expected BinaryFile result"),
+        }
+    }
+
+    #[test]
+    fn test_diff_result_summary() {
+        let diff_result = DiffResult::NoDiff {
+            path: PathBuf::from("/test"),
+            reason: "Already linked".to_string(),
+        };
+        assert_eq!(diff_result.summary(), "Already linked");
+
+        let diff_result = DiffResult::NewFile {
+            source: PathBuf::from("/source"),
+            target: PathBuf::from("/target"),
+            content_preview: vec!["line1".to_string(), "line2".to_string()],
+        };
+        assert_eq!(diff_result.summary(), "New file (2 lines)");
+
+        let diff_result = DiffResult::BinaryFile {
+            source: PathBuf::from("/source"),
+            target: PathBuf::from("/target"),
+        };
+        assert_eq!(diff_result.summary(), "Binary file");
+    }
+}

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 /// A custom error enum for all possible failures in the DotfileManager.
-/// 
+///
 /// This enum uses `thiserror` to provide descriptive error messages and
 /// automatic conversion from standard library error types.
 #[derive(Debug, Error)]

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -3,6 +3,7 @@
 
 use super::config::Config;
 use super::error::ManagerError;
+use super::restore::BackupEntry;
 use chrono::Local;
 use std::fs;
 use std::io;
@@ -263,5 +264,210 @@ impl DotfileManager {
         } else {
             base.join(expanded)
         }
+    }
+
+    /// Lists all backup files in the backup directory.
+    ///
+    /// Returns a vector of BackupEntry structs sorted by timestamp (newest first).
+    /// Each entry contains metadata about the backup including original filename,
+    /// timestamp, size, and target path.
+    ///
+    /// # Returns
+    /// A Result containing a vector of BackupEntry or ManagerError
+    ///
+    /// # Errors
+    /// Returns an error if the backup directory cannot be read
+    pub fn list_backups(&self) -> Result<Vec<BackupEntry>, ManagerError> {
+        // If backup directory doesn't exist, return empty list
+        if !self.backup_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut backups = Vec::new();
+        
+        // Read all files from backup directory
+        for entry in fs::read_dir(&self.backup_path)? {
+            let entry = entry?;
+            let path = entry.path();
+            
+            // Skip directories, only process files
+            if !path.is_file() {
+                continue;
+            }
+            
+            // Parse backup filename
+            if let Some(filename_str) = path.file_name().and_then(|s| s.to_str()) {
+                if let Some((original_name, timestamp)) = BackupEntry::parse_backup_filename(filename_str) {
+                    // Get file metadata
+                    if let Ok(metadata) = fs::metadata(&path) {
+                        // Find matching target from config by looking through all profiles
+                        let mut target_path = None;
+                        for profile in self.config.profiles.values() {
+                            for link in &profile.links {
+                                let link_target = Self::resolve_path(&self.config_dir, &link.target);
+                                if let Some(target_filename) = link_target.file_name() {
+                                    if target_filename.to_string_lossy() == original_name {
+                                        target_path = Some(link_target);
+                                        break;
+                                    }
+                                }
+                            }
+                            if target_path.is_some() {
+                                break;
+                            }
+                        }
+                        
+                        // If no matching config entry, default to home directory
+                        let target_path = target_path.unwrap_or_else(|| {
+                            let home_dir = shellexpand::path::tilde("~");
+                            home_dir.join(&original_name)
+                        });
+                        
+                        backups.push(BackupEntry {
+                            original_name,
+                            timestamp,
+                            backup_path: path.to_path_buf(),
+                            target_path,
+                            file_size: metadata.len(),
+                        });
+                    }
+                }
+            }
+        }
+        
+        // Sort by timestamp, newest first
+        backups.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        
+        Ok(backups)
+    }
+
+    /// Restores a backup file to its original target location.
+    ///
+    /// # Arguments
+    /// * `backup` - The BackupEntry to restore
+    /// * `dry_run` - If true, only simulates the restore without making changes
+    ///
+    /// # Returns
+    /// A Result containing log messages or ManagerError
+    ///
+    /// # Behavior
+    /// - Checks if target location exists
+    /// - If target exists, backs it up before restoring (unless dry_run)
+    /// - Copies the backup file to the target location
+    /// - Removes the backup file from the backup directory
+    pub fn restore_backup(
+        &self,
+        backup: &BackupEntry,
+        dry_run: bool,
+    ) -> Result<Vec<String>, ManagerError> {
+        let mut logs = Vec::new();
+
+        if dry_run {
+            logs.push("--- DRY RUN (No changes will be made) ---".to_string());
+        } else {
+            logs.push(format!(
+                "--- Restoring backup: {} ---",
+                backup.original_name
+            ));
+        }
+
+        logs.push(format!(
+            "Backup file: {}",
+            backup.backup_path.display()
+        ));
+        logs.push(format!(
+            "Target location: {}",
+            backup.target_path.display()
+        ));
+
+        // Check if backup file still exists
+        if !backup.backup_path.exists() {
+            logs.push("[ERROR] Backup file no longer exists".to_string());
+            return Ok(logs);
+        }
+
+        // Check if target location exists
+        if backup.target_path.exists() {
+            // Check if it's a symlink
+            if backup.target_path.is_symlink() {
+                logs.push("[INFO] Target is a symlink, will be removed".to_string());
+                if !dry_run {
+                    fs::remove_file(&backup.target_path)?;
+                }
+            } else {
+                // Regular file/directory - back it up
+                let ts = Local::now().format("%Y%m%d_%H%M%S%.6f");
+                let file_name = backup.target_path.file_name().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("Target path has no filename: {}", backup.target_path.display()),
+                    )
+                })?;
+                let backup_name = format!("{}_{}", file_name.to_string_lossy(), ts);
+                let new_backup_path = self.backup_path.join(backup_name);
+
+                logs.push(format!(
+                    "[BACKUP] Backing up existing file: {} -> {}",
+                    backup.target_path.display(),
+                    new_backup_path.display()
+                ));
+                if !dry_run {
+                    fs::rename(&backup.target_path, new_backup_path)?;
+                }
+            }
+        } else {
+            logs.push("[INFO] Target does not exist, will be created".to_string());
+        }
+
+        // Ensure parent directory exists
+        if let Some(parent) = backup.target_path.parent() {
+            if !parent.exists() {
+                logs.push(format!(
+                    "[CREATE] Creating parent directory: {}",
+                    parent.display()
+                ));
+                if !dry_run {
+                    fs::create_dir_all(parent)?;
+                }
+            }
+        }
+
+        // Copy backup to target location
+        logs.push(format!(
+            "[RESTORE] Copying backup to target: {}",
+            backup.target_path.display()
+        ));
+        if !dry_run {
+            fs::copy(&backup.backup_path, &backup.target_path)?;
+        }
+
+        // Remove the backup file
+        logs.push(format!(
+            "[CLEANUP] Removing backup file: {}",
+            backup.backup_path.display()
+        ));
+        if !dry_run {
+            fs::remove_file(&backup.backup_path)?;
+        }
+
+        logs.push("--- Restore Finished ---".to_string());
+        Ok(logs)
+    }
+
+    /// Deletes a backup file from the backup directory.
+    ///
+    /// # Arguments
+    /// * `backup` - The BackupEntry to delete
+    ///
+    /// # Returns
+    /// A Result indicating success or ManagerError
+    ///
+    /// # Errors
+    /// Returns an error if the file cannot be deleted
+    pub fn delete_backup(&self, backup: &BackupEntry) -> Result<(), ManagerError> {
+        if backup.backup_path.exists() {
+            fs::remove_file(&backup.backup_path)?;
+        }
+        Ok(())
     }
 }

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -2,6 +2,7 @@
 //! The main DotfileManager struct and its associated logic.
 
 use super::config::Config;
+use super::diff::{generate_diff, DiffResult};
 use super::error::ManagerError;
 use super::restore::BackupEntry;
 use chrono::Local;
@@ -473,5 +474,35 @@ impl DotfileManager {
             fs::remove_file(&backup.backup_path)?;
         }
         Ok(())
+    }
+
+    /// Generates diff previews for all links in a profile.
+    ///
+    /// # Arguments
+    /// * `profile_name` - Name of the profile to preview
+    ///
+    /// # Returns
+    /// A vector of DiffResult for each link in the profile
+    ///
+    /// # Errors
+    /// Returns an error if the profile is not found
+    pub fn preview_diff(&self, profile_name: &str) -> Result<Vec<DiffResult>, ManagerError> {
+        let profile = self
+            .config
+            .profiles
+            .get(profile_name)
+            .ok_or_else(|| ManagerError::ProfileNotFound(profile_name.to_string()))?;
+
+        let mut results = Vec::new();
+
+        for link in &profile.links {
+            let source = Self::resolve_path(&self.repo_path, &link.source);
+            let target = Self::resolve_path(&self.config_dir, &link.target);
+
+            let diff = generate_diff(&source, &target);
+            results.push(diff);
+        }
+
+        Ok(results)
     }
 }

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -386,37 +386,41 @@ impl DotfileManager {
             return Ok(logs);
         }
 
-        // Check if target location exists
-        if backup.target_path.exists() {
-            // Check if it's a symlink
-            if backup.target_path.is_symlink() {
-                logs.push("[INFO] Target is a symlink, will be removed".to_string());
-                if !dry_run {
-                    fs::remove_file(&backup.target_path)?;
-                }
-            } else {
-                // Regular file/directory - back it up
-                let ts = Local::now().format("%Y%m%d_%H%M%S%.6f");
-                let file_name = backup.target_path.file_name().ok_or_else(|| {
-                    io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!("Target path has no filename: {}", backup.target_path.display()),
-                    )
-                })?;
-                let backup_name = format!("{}_{}", file_name.to_string_lossy(), ts);
-                let new_backup_path = self.backup_path.join(backup_name);
+        // Check if target location exists (including broken symlinks)
+        // Use symlink_metadata to detect symlinks even if they're broken
+        match fs::symlink_metadata(&backup.target_path) {
+            Ok(metadata) => {
+                if metadata.is_symlink() {
+                    logs.push("[INFO] Target is a symlink, will be removed".to_string());
+                    if !dry_run {
+                        fs::remove_file(&backup.target_path)?;
+                    }
+                } else {
+                    // Regular file/directory - back it up
+                    let ts = Local::now().format("%Y%m%d_%H%M%S%.6f");
+                    let file_name = backup.target_path.file_name().ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Target path has no filename: {}", backup.target_path.display()),
+                        )
+                    })?;
+                    let backup_name = format!("{}_{}", file_name.to_string_lossy(), ts);
+                    let new_backup_path = self.backup_path.join(backup_name);
 
-                logs.push(format!(
-                    "[BACKUP] Backing up existing file: {} -> {}",
-                    backup.target_path.display(),
-                    new_backup_path.display()
-                ));
-                if !dry_run {
-                    fs::rename(&backup.target_path, new_backup_path)?;
+                    logs.push(format!(
+                        "[BACKUP] Backing up existing file: {} -> {}",
+                        backup.target_path.display(),
+                        new_backup_path.display()
+                    ));
+                    if !dry_run {
+                        fs::rename(&backup.target_path, new_backup_path)?;
+                    }
                 }
             }
-        } else {
-            logs.push("[INFO] Target does not exist, will be created".to_string());
+            Err(_) => {
+                // Target does not exist
+                logs.push("[INFO] Target does not exist, will be created".to_string());
+            }
         }
 
         // Ensure parent directory exists

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -95,6 +95,21 @@ impl DotfileManager {
         profiles
     }
 
+    /// Returns the number of links for a given profile.
+    ///
+    /// # Arguments
+    /// * `profile_name` - Name of the profile
+    ///
+    /// # Returns
+    /// The number of links in the profile, or 0 if the profile doesn't exist.
+    pub fn get_profile_link_count(&self, profile_name: &str) -> usize {
+        self.config
+            .profiles
+            .get(profile_name)
+            .map(|p| p.links.len())
+            .unwrap_or(0)
+    }
+
     /// Executes the sync, either for real or as a dry run.
     /// Returns a list of log messages.
     pub fn execute_sync(
@@ -102,6 +117,25 @@ impl DotfileManager {
         profile_name: &str,
         dry_run: bool,
     ) -> Result<Vec<String>, ManagerError> {
+        self.execute_sync_with_progress(profile_name, dry_run, |_, _, _| {})
+    }
+
+    /// Executes the sync with progress reporting, either for real or as a dry run.
+    /// Returns a list of log messages.
+    ///
+    /// # Arguments
+    /// * `profile_name` - Name of the profile to sync
+    /// * `dry_run` - If true, only simulates changes without applying them
+    /// * `progress_callback` - Function called for each file processed: (current, total, filename)
+    pub fn execute_sync_with_progress<F>(
+        &self,
+        profile_name: &str,
+        dry_run: bool,
+        progress_callback: F,
+    ) -> Result<Vec<String>, ManagerError>
+    where
+        F: Fn(usize, usize, &str),
+    {
         let mut logs = Vec::new();
 
         if dry_run {
@@ -120,16 +154,24 @@ impl DotfileManager {
             .get(profile_name)
             .ok_or_else(|| ManagerError::ProfileNotFound(profile_name.to_string()))?;
 
-        for link in &profile.links {
+        let total_files = profile.links.len();
+
+        for (index, link) in profile.links.iter().enumerate() {
             let source = Self::resolve_path(&self.repo_path, &link.source);
             let target = Self::resolve_path(&self.config_dir, &link.target);
 
+            let current_file = source
+                .strip_prefix(&self.repo_path)
+                .unwrap_or(&source)
+                .display()
+                .to_string();
+
+            // Report progress
+            progress_callback(index + 1, total_files, &current_file);
+
             logs.push(format!(
                 "Processing: {} -> {}",
-                source
-                    .strip_prefix(&self.repo_path)
-                    .unwrap_or(&source)
-                    .display(),
+                current_file,
                 target.display()
             ));
 

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -284,27 +284,30 @@ impl DotfileManager {
         }
 
         let mut backups = Vec::new();
-        
+
         // Read all files from backup directory
         for entry in fs::read_dir(&self.backup_path)? {
             let entry = entry?;
             let path = entry.path();
-            
+
             // Skip directories, only process files
             if !path.is_file() {
                 continue;
             }
-            
+
             // Parse backup filename
             if let Some(filename_str) = path.file_name().and_then(|s| s.to_str()) {
-                if let Some((original_name, timestamp)) = BackupEntry::parse_backup_filename(filename_str) {
+                if let Some((original_name, timestamp)) =
+                    BackupEntry::parse_backup_filename(filename_str)
+                {
                     // Get file metadata
                     if let Ok(metadata) = fs::metadata(&path) {
                         // Find matching target from config by looking through all profiles
                         let mut target_path = None;
                         for profile in self.config.profiles.values() {
                             for link in &profile.links {
-                                let link_target = Self::resolve_path(&self.config_dir, &link.target);
+                                let link_target =
+                                    Self::resolve_path(&self.config_dir, &link.target);
                                 if let Some(target_filename) = link_target.file_name() {
                                     if target_filename.to_string_lossy() == original_name {
                                         target_path = Some(link_target);
@@ -316,13 +319,13 @@ impl DotfileManager {
                                 break;
                             }
                         }
-                        
+
                         // If no matching config entry, default to home directory
                         let target_path = target_path.unwrap_or_else(|| {
                             let home_dir = shellexpand::path::tilde("~");
                             home_dir.join(&original_name)
                         });
-                        
+
                         backups.push(BackupEntry {
                             original_name,
                             timestamp,
@@ -334,10 +337,10 @@ impl DotfileManager {
                 }
             }
         }
-        
+
         // Sort by timestamp, newest first
         backups.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-        
+
         Ok(backups)
     }
 
@@ -371,14 +374,8 @@ impl DotfileManager {
             ));
         }
 
-        logs.push(format!(
-            "Backup file: {}",
-            backup.backup_path.display()
-        ));
-        logs.push(format!(
-            "Target location: {}",
-            backup.target_path.display()
-        ));
+        logs.push(format!("Backup file: {}", backup.backup_path.display()));
+        logs.push(format!("Target location: {}", backup.target_path.display()));
 
         // Check if backup file still exists
         if !backup.backup_path.exists() {
@@ -401,7 +398,10 @@ impl DotfileManager {
                     let file_name = backup.target_path.file_name().ok_or_else(|| {
                         io::Error::new(
                             io::ErrorKind::InvalidInput,
-                            format!("Target path has no filename: {}", backup.target_path.display()),
+                            format!(
+                                "Target path has no filename: {}",
+                                backup.target_path.display()
+                            ),
                         )
                     })?;
                     let backup_name = format!("{}_{}", file_name.to_string_lossy(), ts);

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -75,6 +75,60 @@ impl DotfileManager {
         })
     }
 
+    /// Reloads the configuration from the specified file.
+    ///
+    /// This method re-reads and re-parses the configuration file, updating
+    /// all internal state including profiles, repo_path, and backup_path.
+    ///
+    /// # Arguments
+    /// * `config_path` - Path to the TOML configuration file
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The configuration file doesn't exist
+    /// - The file cannot be read
+    /// - The TOML is invalid
+    /// - The configuration fails validation
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use std::path::Path;
+    /// # use tui_dotfile_manager::DotfileManager;
+    /// # let mut manager = DotfileManager::new(Path::new("config.toml"))?;
+    /// manager.reload_config(Path::new("config.toml"))?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    pub fn reload_config(&mut self, config_path: &Path) -> Result<(), ManagerError> {
+        if !config_path.exists() {
+            return Err(ManagerError::ConfigNotFound(config_path.to_path_buf()));
+        }
+
+        let config_str = fs::read_to_string(config_path)?;
+        let config: Config = toml::from_str(&config_str)?;
+
+        // Validate configuration
+        if let Err(e) = config.validate() {
+            return Err(ManagerError::ConfigValidation(e));
+        }
+
+        let config_dir = config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+
+        // Resolve paths relative to the config file or home dir
+        let repo_path = Self::resolve_path(&config_dir, &config.settings.repo_dir);
+        let backup_path = Self::resolve_path(&config_dir, &config.settings.backup_dir);
+
+        // Update internal state
+        self.config = config;
+        self.repo_path = repo_path;
+        self.backup_path = backup_path;
+        self.config_dir = config_dir;
+
+        Ok(())
+    }
+
     /// Returns a sorted list of available profile names.
     ///
     /// Profile names are sorted alphabetically for consistent display

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -9,7 +9,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 /// Encapsulates all dotfile management logic.
-/// 
+///
 /// The manager is responsible for loading configuration, resolving paths,
 /// and executing sync operations. It is stateless after initialization
 /// and can be safely shared across threads.
@@ -23,22 +23,22 @@ pub struct DotfileManager {
 
 impl DotfileManager {
     /// Creates a new manager by loading and parsing the config file.
-    /// 
+    ///
     /// # Arguments
     /// * `config_path` - Path to the TOML configuration file
-    /// 
+    ///
     /// # Errors
     /// Returns an error if:
     /// - The configuration file doesn't exist
     /// - The file cannot be read
     /// - The TOML is invalid
     /// - The configuration fails validation
-    /// 
+    ///
     /// # Example
     /// ```no_run
     /// use std::path::Path;
     /// use tui_dotfile_manager::DotfileManager;
-    /// 
+    ///
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let manager = DotfileManager::new(Path::new("config.toml"))?;
     ///     Ok(())
@@ -51,7 +51,7 @@ impl DotfileManager {
 
         let config_str = fs::read_to_string(config_path)?;
         let config: Config = toml::from_str(&config_str)?;
-        
+
         // Validate configuration
         if let Err(e) = config.validate() {
             return Err(ManagerError::ConfigValidation(e));
@@ -75,10 +75,10 @@ impl DotfileManager {
     }
 
     /// Returns a sorted list of available profile names.
-    /// 
+    ///
     /// Profile names are sorted alphabetically for consistent display
     /// in the user interface.
-    /// 
+    ///
     /// # Example
     /// ```no_run
     /// # use std::path::Path;
@@ -137,10 +137,7 @@ impl DotfileManager {
                     "  [WARN] Source file does not exist: {}",
                     link.source.display()
                 ));
-                logs.push(format!(
-                    "         Expected at: {}",
-                    source.display()
-                ));
+                logs.push(format!("         Expected at: {}", source.display()));
                 continue;
             }
 
@@ -186,13 +183,12 @@ impl DotfileManager {
                     // Not a symlink, treat as file or directory
                     let ts = Local::now().format("%Y%m%d_%H%M%S%.6f");
                     let file_name = target.file_name().ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidInput, format!("Target path has no filename: {}", target.display()))
+                        io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Target path has no filename: {}", target.display()),
+                        )
                     })?;
-                    let backup_name = format!(
-                        "{}_{}",
-                        file_name.to_string_lossy(),
-                        ts
-                    );
+                    let backup_name = format!("{}_{}", file_name.to_string_lossy(), ts);
                     let backup_path = self.backup_path.join(backup_name);
 
                     logs.push(format!(
@@ -230,7 +226,7 @@ impl DotfileManager {
     }
 
     /// Creates a platform-aware symlink (file vs. dir on Windows).
-    /// 
+    ///
     /// On Windows, different functions are needed for file and directory symlinks.
     #[cfg(windows)]
     fn create_symlink(&self, source: &Path, target: &Path) -> Result<(), io::Error> {
@@ -242,7 +238,7 @@ impl DotfileManager {
     }
 
     /// Creates a platform-aware symlink (Unix).
-    /// 
+    ///
     /// On Unix-like systems, a single function handles both files and directories.
     #[cfg(not(windows))]
     fn create_symlink(&self, source: &Path, target: &Path) -> Result<(), io::Error> {
@@ -250,11 +246,11 @@ impl DotfileManager {
     }
 
     /// Helper to expand '~' and resolve paths.
-    /// 
+    ///
     /// # Arguments
     /// * `base` - Base directory for relative paths
     /// * `p` - Path to resolve (may contain ~ or be relative/absolute)
-    /// 
+    ///
     /// # Behavior
     /// - Expands ~ to the user's home directory
     /// - If the path is absolute (after expansion), returns it as-is

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@
 //! Core module: contains all the business logic.
 
 pub mod config;
+pub mod diff;
 pub mod error;
 pub mod manager;
 pub mod restore;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@
 pub mod config;
 pub mod error;
 pub mod manager;
+pub mod restore;
 
 // Publicly export the main components for library usage.
 // ManagerError is re-exported for external crates that might use this as a library.

--- a/src/core/restore.rs
+++ b/src/core/restore.rs
@@ -1,0 +1,188 @@
+// Author: Jacques Murray
+//! Backup restoration logic and backup entry management.
+
+use chrono::{DateTime, Local, NaiveDateTime, TimeZone};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Represents a single backed-up file with metadata.
+///
+/// BackupEntry contains all information needed to display, restore,
+/// or delete a backup file.
+#[derive(Debug, Clone)]
+pub struct BackupEntry {
+    /// Original filename (e.g., ".bashrc")
+    pub original_name: String,
+    /// Timestamp when the backup was created
+    pub timestamp: DateTime<Local>,
+    /// Full path to the backup file
+    pub backup_path: PathBuf,
+    /// Expected target path for restoration
+    pub target_path: PathBuf,
+    /// Size of the backup file in bytes
+    pub file_size: u64,
+}
+
+impl BackupEntry {
+    /// Parses a backup filename to extract the original name and timestamp.
+    ///
+    /// # Arguments
+    /// * `filename` - Backup filename (e.g., ".bashrc_20241114_143052.123456")
+    ///
+    /// # Returns
+    /// Some((original_name, timestamp)) if parsing succeeds, None otherwise
+    ///
+    /// # Example
+    /// ```
+    /// use tui_dotfile_manager::core::restore::BackupEntry;
+    ///
+    /// let result = BackupEntry::parse_backup_filename(".bashrc_20241114_143052.123456");
+    /// assert!(result.is_some());
+    /// ```
+    pub fn parse_backup_filename(filename: &str) -> Option<(String, DateTime<Local>)> {
+        // Expected format: <original_name>_<YYYYMMDD>_<HHMMSS>.<microseconds>
+        // Example: .bashrc_20241114_143052.123456
+        
+        // Find the last underscore before the time component
+        let parts: Vec<&str> = filename.rsplitn(2, '_').collect();
+        if parts.len() != 2 {
+            return None;
+        }
+        
+        let time_part = parts[0]; // "143052.123456"
+        let remaining = parts[1]; // ".bashrc_20241114"
+        
+        // Find the second-to-last underscore to separate date
+        let parts2: Vec<&str> = remaining.rsplitn(2, '_').collect();
+        if parts2.len() != 2 {
+            return None;
+        }
+        
+        let date_part = parts2[0]; // "20241114"
+        let original_name = parts2[1]; // ".bashrc"
+        
+        // Parse timestamp: date_part + time_part
+        let timestamp_str = format!("{}_{}", date_part, time_part);
+        
+        // Parse format: YYYYMMDD_HHMMSS.microseconds
+        let dt = NaiveDateTime::parse_from_str(&timestamp_str, "%Y%m%d_%H%M%S%.6f").ok()?;
+        let local_dt = Local.from_local_datetime(&dt).single()?;
+        
+        Some((original_name.to_string(), local_dt))
+    }
+
+    /// Creates a BackupEntry from a backup file path.
+    ///
+    /// # Arguments
+    /// * `backup_path` - Path to the backup file
+    /// * `target_base` - Base directory for resolving target paths (e.g., home directory)
+    ///
+    /// # Returns
+    /// Some(BackupEntry) if the file is a valid backup, None otherwise
+    pub fn from_path(backup_path: &Path, target_base: &Path) -> Option<Self> {
+        let filename = backup_path.file_name()?.to_str()?;
+        let (original_name, timestamp) = Self::parse_backup_filename(filename)?;
+        
+        // Get file metadata
+        let metadata = fs::metadata(backup_path).ok()?;
+        let file_size = metadata.len();
+        
+        // Construct expected target path
+        let target_path = target_base.join(&original_name);
+        
+        Some(BackupEntry {
+            original_name,
+            timestamp,
+            backup_path: backup_path.to_path_buf(),
+            target_path,
+            file_size,
+        })
+    }
+
+    /// Formats the file size in a human-readable format.
+    pub fn format_size(&self) -> String {
+        let size = self.file_size;
+        if size < 1024 {
+            format!("{} B", size)
+        } else if size < 1024 * 1024 {
+            format!("{:.1} KB", size as f64 / 1024.0)
+        } else if size < 1024 * 1024 * 1024 {
+            format!("{:.1} MB", size as f64 / (1024.0 * 1024.0))
+        } else {
+            format!("{:.1} GB", size as f64 / (1024.0 * 1024.0 * 1024.0))
+        }
+    }
+
+    /// Reads and returns the first N lines of the backup file.
+    ///
+    /// # Arguments
+    /// * `max_lines` - Maximum number of lines to read
+    ///
+    /// # Returns
+    /// A vector of strings, one per line, or an error if reading fails
+    pub fn preview_content(&self, max_lines: usize) -> io::Result<Vec<String>> {
+        let content = fs::read_to_string(&self.backup_path)?;
+        Ok(content
+            .lines()
+            .take(max_lines)
+            .map(|s| s.to_string())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_backup_filename_valid() {
+        let filename = ".bashrc_20241114_143052.123456";
+        let result = BackupEntry::parse_backup_filename(filename);
+        
+        assert!(result.is_some());
+        let (name, _timestamp) = result.unwrap();
+        assert_eq!(name, ".bashrc");
+    }
+
+    #[test]
+    fn test_parse_backup_filename_with_underscores() {
+        let filename = "my_config_file_20241114_143052.123456";
+        let result = BackupEntry::parse_backup_filename(filename);
+        
+        assert!(result.is_some());
+        let (name, _timestamp) = result.unwrap();
+        assert_eq!(name, "my_config_file");
+    }
+
+    #[test]
+    fn test_parse_backup_filename_invalid() {
+        let invalid_filenames = vec![
+            "invalid",
+            ".bashrc_invalid_timestamp",
+            "no_timestamp",
+            ".bashrc_20241114",
+        ];
+        
+        for filename in invalid_filenames {
+            assert!(
+                BackupEntry::parse_backup_filename(filename).is_none(),
+                "Should fail for: {}",
+                filename
+            );
+        }
+    }
+
+    #[test]
+    fn test_format_size() {
+        let entry = BackupEntry {
+            original_name: "test".to_string(),
+            timestamp: Local::now(),
+            backup_path: PathBuf::from("/tmp/test"),
+            target_path: PathBuf::from("/tmp/target"),
+            file_size: 1024,
+        };
+        
+        assert_eq!(entry.format_size(), "1.0 KB");
+    }
+}

--- a/src/core/restore.rs
+++ b/src/core/restore.rs
@@ -43,32 +43,32 @@ impl BackupEntry {
     pub fn parse_backup_filename(filename: &str) -> Option<(String, DateTime<Local>)> {
         // Expected format: <original_name>_<YYYYMMDD>_<HHMMSS>.<microseconds>
         // Example: .bashrc_20241114_143052.123456
-        
+
         // Find the last underscore before the time component
         let parts: Vec<&str> = filename.rsplitn(2, '_').collect();
         if parts.len() != 2 {
             return None;
         }
-        
+
         let time_part = parts[0]; // "143052.123456"
         let remaining = parts[1]; // ".bashrc_20241114"
-        
+
         // Find the second-to-last underscore to separate date
         let parts2: Vec<&str> = remaining.rsplitn(2, '_').collect();
         if parts2.len() != 2 {
             return None;
         }
-        
+
         let date_part = parts2[0]; // "20241114"
         let original_name = parts2[1]; // ".bashrc"
-        
+
         // Parse timestamp: date_part + time_part
         let timestamp_str = format!("{}_{}", date_part, time_part);
-        
+
         // Parse format: YYYYMMDD_HHMMSS.microseconds
         let dt = NaiveDateTime::parse_from_str(&timestamp_str, "%Y%m%d_%H%M%S%.6f").ok()?;
         let local_dt = Local.from_local_datetime(&dt).single()?;
-        
+
         Some((original_name.to_string(), local_dt))
     }
 
@@ -80,17 +80,18 @@ impl BackupEntry {
     ///
     /// # Returns
     /// Some(BackupEntry) if the file is a valid backup, None otherwise
+    #[allow(dead_code)]
     pub fn from_path(backup_path: &Path, target_base: &Path) -> Option<Self> {
         let filename = backup_path.file_name()?.to_str()?;
         let (original_name, timestamp) = Self::parse_backup_filename(filename)?;
-        
+
         // Get file metadata
         let metadata = fs::metadata(backup_path).ok()?;
         let file_size = metadata.len();
-        
+
         // Construct expected target path
         let target_path = target_base.join(&original_name);
-        
+
         Some(BackupEntry {
             original_name,
             timestamp,
@@ -139,7 +140,7 @@ mod tests {
     fn test_parse_backup_filename_valid() {
         let filename = ".bashrc_20241114_143052.123456";
         let result = BackupEntry::parse_backup_filename(filename);
-        
+
         assert!(result.is_some());
         let (name, _timestamp) = result.unwrap();
         assert_eq!(name, ".bashrc");
@@ -149,7 +150,7 @@ mod tests {
     fn test_parse_backup_filename_with_underscores() {
         let filename = "my_config_file_20241114_143052.123456";
         let result = BackupEntry::parse_backup_filename(filename);
-        
+
         assert!(result.is_some());
         let (name, _timestamp) = result.unwrap();
         assert_eq!(name, "my_config_file");
@@ -163,7 +164,7 @@ mod tests {
             "no_timestamp",
             ".bashrc_20241114",
         ];
-        
+
         for filename in invalid_filenames {
             assert!(
                 BackupEntry::parse_backup_filename(filename).is_none(),
@@ -182,7 +183,7 @@ mod tests {
             target_path: PathBuf::from("/tmp/target"),
             file_size: 1024,
         };
-        
+
         assert_eq!(entry.format_size(), "1.0 KB");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod core;
 mod tui;
 
 use anyhow::Result;
+use clap::Parser;
 use crossterm::{
     event::DisableMouseCapture,
     execute,
@@ -22,38 +23,85 @@ use tui::{
     event::{self, Event},
 };
 
+/// TUI Dotfile Manager - Manage your dotfiles with symlinks
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to configuration file
+    #[arg(short, long, default_value = "config.toml")]
+    config: PathBuf,
+
+    /// Profile to sync (skips TUI if provided)
+    #[arg(short, long)]
+    profile: Option<String>,
+
+    /// Perform a dry run without making changes
+    #[arg(short, long)]
+    dry_run: bool,
+
+    /// List available profiles and exit
+    #[arg(short, long)]
+    list_profiles: bool,
+}
+
 fn main() -> Result<()> {
+    // Parse CLI arguments
+    let args = Args::parse();
+
     // 1. Setup the DotfileManager
-    // We look for config.toml in the current directory.
-    let config_path = PathBuf::from("config.toml");
-    let manager = core::DotfileManager::new(&config_path).map_err(|e| {
-        // If TUI setup fails, we must print to stderr.
+    let manager = core::DotfileManager::new(&args.config).map_err(|e| {
+        // If config loading fails, we must print to stderr before the TUI is initialized.
         eprintln!("Failed to load configuration: {}", e);
-        eprintln!("Please ensure 'config.toml' exists and is valid.");
+        eprintln!("Config path: {}", args.config.display());
+        eprintln!("Please ensure the configuration file exists and is valid.");
         e
     })?;
+
+    // 2. List profiles mode - print profiles and exit
+    if args.list_profiles {
+        println!("Available profiles:");
+        for profile in manager.get_profiles() {
+            println!("  - {}", profile);
+        }
+        return Ok(());
+    }
+
+    // 3. Headless mode - execute sync directly without TUI
+    if let Some(profile) = args.profile {
+        let logs = manager.execute_sync(&profile, args.dry_run)?;
+        for log in logs {
+            println!("{}", log);
+        }
+        return Ok(());
+    }
+
+    // 4. Interactive TUI mode (existing behavior)
     let manager_arc = Arc::new(manager);
 
-    // 2. Setup channels for communication
+    // Setup channels for communication
     // event_tx/event_rx: For TUI events (keys, ticks)
     // log_tx/log_rx: For logs from the sync worker thread
     let (event_tx, event_rx) = mpsc::channel();
     let (log_tx, log_rx) = mpsc::channel::<WorkerMessage>();
 
-    // 3. Setup the TUI
+    // Setup the TUI
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, crossterm::event::EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        crossterm::event::EnableMouseCapture
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // 4. Create the App state
+    // Create the App state
     let mut app = App::new(manager_arc, log_tx);
 
-    // 5. Start the event listener thread
+    // Start the event listener thread
     event::run(event_tx)?;
 
-    // 6. Run the main event loop
+    // Run the main event loop
     while !app.should_quit {
         // Draw the UI
         terminal.draw(|f| tui::render(f, &app))?;
@@ -74,7 +122,7 @@ fn main() -> Result<()> {
         }
     }
 
-    // 7. Restore terminal
+    // Restore terminal
     disable_raw_mode()?;
     execute!(
         terminal.backend_mut(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{
     io,
     path::PathBuf,
-    sync::{mpsc, Arc},
+    sync::{mpsc, Arc, RwLock},
 };
 use tui::{
     app::{App, WorkerMessage},
@@ -76,7 +76,7 @@ fn main() -> Result<()> {
     }
 
     // 4. Interactive TUI mode (existing behavior)
-    let manager_arc = Arc::new(manager);
+    let manager_arc = Arc::new(RwLock::new(manager));
 
     // Setup channels for communication
     // event_tx/event_rx: For TUI events (keys, ticks)
@@ -96,7 +96,7 @@ fn main() -> Result<()> {
     let mut terminal = Terminal::new(backend)?;
 
     // Create the App state
-    let mut app = App::new(manager_arc, log_tx);
+    let mut app = App::new(manager_arc, args.config.clone(), log_tx);
 
     // Start the event listener thread
     event::run(event_tx)?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -27,6 +27,16 @@ pub enum WorkerMessage {
     SyncComplete,
     RestoreComplete,
     BackupsListed(Vec<BackupEntry>),
+    SyncStarted { total_files: usize },
+    Progress { current: usize, total: usize, file: String },
+}
+
+/// Tracks sync progress for UI display.
+#[derive(Debug, Clone)]
+pub struct SyncProgress {
+    pub current: usize,
+    pub total: usize,
+    pub current_file: String,
 }
 
 /// Represents the TUI's state and logic.
@@ -41,6 +51,7 @@ pub struct App {
     pub logs: VecDeque<String>,
     pub should_quit: bool,
     pub sync_in_progress: bool,
+    pub sync_progress: Option<SyncProgress>,
     pub mode: AppMode,
     pub backups: Vec<BackupEntry>,
     pub selected_backup: Option<usize>,
@@ -72,6 +83,7 @@ impl App {
             ]),
             should_quit: false,
             sync_in_progress: false,
+            sync_progress: None,
             mode: AppMode::Sync,
             backups: Vec::new(),
             selected_backup: None,
@@ -261,7 +273,20 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                match manager.execute_sync(&profile_name, dry_run) {
+                // Get the total number of files
+                let total_files = manager.get_profile_link_count(&profile_name);
+
+                // Send sync started message
+                log_tx.send(WorkerMessage::SyncStarted { total_files }).ok();
+
+                // Execute sync with progress callback
+                match manager.execute_sync_with_progress(&profile_name, dry_run, |current, total, file| {
+                    log_tx.send(WorkerMessage::Progress {
+                        current,
+                        total,
+                        file: file.to_string(),
+                    }).ok();
+                }) {
                     Ok(logs) => {
                         for log in logs {
                             log_tx.send(WorkerMessage::Log(log)).ok();
@@ -418,6 +443,7 @@ impl App {
             }
             WorkerMessage::SyncComplete => {
                 self.sync_in_progress = false;
+                self.sync_progress = None;
             }
             WorkerMessage::RestoreComplete => {
                 self.restore_in_progress = false;
@@ -429,6 +455,20 @@ impl App {
                 self.backups = backups;
                 self.selected_backup = if count > 0 { Some(0) } else { None };
                 self.logs.push_back(format!("Found {} backup(s)", count));
+            }
+            WorkerMessage::SyncStarted { total_files } => {
+                self.sync_progress = Some(SyncProgress {
+                    current: 0,
+                    total: total_files,
+                    current_file: String::new(),
+                });
+            }
+            WorkerMessage::Progress { current, total, file } => {
+                self.sync_progress = Some(SyncProgress {
+                    current,
+                    total,
+                    current_file: file,
+                });
             }
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5,7 +5,8 @@ use crate::core::restore::BackupEntry;
 use crate::core::DotfileManager;
 use crossterm::event::KeyCode;
 use std::collections::VecDeque;
-use std::sync::{mpsc, Arc};
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 
 /// Maximum number of log messages to keep in memory.
@@ -35,7 +36,8 @@ pub enum WorkerMessage {
 /// log messages, and sync status. It handles user input and coordinates with
 /// background worker threads for I/O operations.
 pub struct App {
-    pub manager: Arc<DotfileManager>,
+    pub manager: Arc<RwLock<DotfileManager>>,
+    pub config_path: PathBuf,
     pub profiles: Vec<String>,
     pub selected_profile: Option<usize>,
     pub logs: VecDeque<String>,
@@ -53,22 +55,28 @@ impl App {
     ///
     /// # Arguments
     /// * `manager` - Shared reference to the DotfileManager
+    /// * `config_path` - Path to the configuration file for reloading
     /// * `log_tx` - Channel sender for receiving log messages from worker threads
     ///
     /// # Returns
     /// A new App instance with initial welcome messages and the first profile selected.
-    pub fn new(manager: Arc<DotfileManager>, log_tx: mpsc::Sender<WorkerMessage>) -> Self {
-        let profiles = manager.get_profiles();
+    pub fn new(
+        manager: Arc<RwLock<DotfileManager>>,
+        config_path: PathBuf,
+        log_tx: mpsc::Sender<WorkerMessage>,
+    ) -> Self {
+        let profiles = manager.read().unwrap().get_profiles();
         let selected_profile = if profiles.is_empty() { None } else { Some(0) };
 
         Self {
             manager,
+            config_path,
             profiles,
             selected_profile,
             logs: VecDeque::from([
                 "Welcome to the TUI Dotfile Manager!".to_string(),
                 "Use 'j'/'k' or Arrow Up/Down to select a profile.".to_string(),
-                "'s' = Sync, 'd' = Dry Run, 'r' = Restore Mode, 'q' = Quit.".to_string(),
+                "'s' = Sync, 'd' = Dry Run, 'R' = Reload Config, 'r' = Restore Mode, 'q' = Quit.".to_string(),
             ]),
             should_quit: false,
             sync_in_progress: false,
@@ -118,6 +126,7 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => self.select_previous_profile(),
             KeyCode::Char('d') => self.start_sync(true),
             KeyCode::Char('s') | KeyCode::Enter => self.start_sync(false),
+            KeyCode::Char('R') => self.reload_config(),
             KeyCode::Char('r') => self.enter_restore_mode(),
             _ => {}
         }
@@ -210,18 +219,24 @@ impl App {
         let log_tx = self.log_tx.clone();
 
         // Spawn a thread to list backups
-        thread::spawn(move || match manager.list_backups() {
-            Ok(backups) => {
-                log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
-            }
-            Err(e) => {
-                log_tx
-                    .send(WorkerMessage::Log(format!(
-                        "[ERROR] Failed to list backups: {}",
-                        e
-                    )))
-                    .ok();
-                log_tx.send(WorkerMessage::BackupsListed(Vec::new())).ok();
+        thread::spawn(move || {
+            let result = {
+                let manager_read = manager.read().unwrap();
+                manager_read.list_backups()
+            };
+            match result {
+                Ok(backups) => {
+                    log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
+                }
+                Err(e) => {
+                    log_tx
+                        .send(WorkerMessage::Log(format!(
+                            "[ERROR] Failed to list backups: {}",
+                            e
+                        )))
+                        .ok();
+                    log_tx.send(WorkerMessage::BackupsListed(Vec::new())).ok();
+                }
             }
         });
     }
@@ -233,6 +248,90 @@ impl App {
         self.selected_backup = None;
         self.logs.push_back("---".to_string());
         self.logs.push_back("Exited Restore Mode".to_string());
+    }
+
+    /// Reloads the configuration file and updates the profile list.
+    ///
+    /// This method:
+    /// - Re-reads and parses the config file
+    /// - Updates the profile list
+    /// - Adjusts profile selection if needed
+    /// - Provides user feedback
+    /// - Handles errors gracefully without crashing
+    fn reload_config(&mut self) {
+        if self.sync_in_progress {
+            self.logs.push_back("---".to_string());
+            self.logs
+                .push_back("[WARN] Cannot reload config during sync.".to_string());
+            return;
+        }
+
+        if self.restore_in_progress {
+            self.logs.push_back("---".to_string());
+            self.logs
+                .push_back("[WARN] Cannot reload config during restore.".to_string());
+            return;
+        }
+
+        self.logs.push_back("---".to_string());
+        self.logs
+            .push_back("Reloading configuration...".to_string());
+
+        // Attempt to reload the configuration
+        let result = {
+            let mut manager = self.manager.write().unwrap();
+            manager.reload_config(&self.config_path)
+        };
+
+        match result {
+            Ok(()) => {
+                // Update profile list
+                let old_profiles = std::mem::take(&mut self.profiles);
+                self.profiles = self.manager.read().unwrap().get_profiles();
+
+                // Handle selection adjustment
+                let old_selected_name = self
+                    .selected_profile
+                    .and_then(|idx| old_profiles.get(idx))
+                    .cloned();
+
+                if let Some(old_name) = old_selected_name {
+                    // Try to find the previously selected profile in the new list
+                    self.selected_profile = self
+                        .profiles
+                        .iter()
+                        .position(|name| name == &old_name)
+                        .or_else(|| {
+                            if !self.profiles.is_empty() {
+                                self.logs.push_back(format!(
+                                    "[INFO] Profile '{}' no longer exists. Switched to '{}'.",
+                                    old_name, self.profiles[0]
+                                ));
+                                Some(0)
+                            } else {
+                                None
+                            }
+                        });
+                } else if !self.profiles.is_empty() {
+                    self.selected_profile = Some(0);
+                } else {
+                    self.selected_profile = None;
+                }
+
+                // Success message
+                self.logs.push_back(format!(
+                    "[SUCCESS] Configuration reloaded. {} profile(s) available.",
+                    self.profiles.len()
+                ));
+            }
+            Err(e) => {
+                // Error handling - don't crash, just log the error
+                self.logs
+                    .push_back(format!("[ERROR] Failed to reload configuration: {}", e));
+                self.logs
+                    .push_back("[INFO] Using previous configuration.".to_string());
+            }
+        }
     }
 
     /// Spawns a worker thread to perform the sync.
@@ -261,7 +360,11 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                match manager.execute_sync(&profile_name, dry_run) {
+                let result = {
+                    let manager_read = manager.read().unwrap();
+                    manager_read.execute_sync(&profile_name, dry_run)
+                };
+                match result {
                     Ok(logs) => {
                         for log in logs {
                             log_tx.send(WorkerMessage::Log(log)).ok();
@@ -318,7 +421,11 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                match manager.restore_backup(&backup, dry_run) {
+                let result = {
+                    let manager_read = manager.read().unwrap();
+                    manager_read.restore_backup(&backup, dry_run)
+                };
+                match result {
                     Ok(logs) => {
                         for log in logs {
                             log_tx.send(WorkerMessage::Log(log)).ok();
@@ -364,33 +471,39 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                match manager.delete_backup(&backup) {
-                    Ok(()) => {
-                        log_tx
-                            .send(WorkerMessage::Log("[SUCCESS] Backup deleted".to_string()))
-                            .ok();
-                    }
-                    Err(e) => {
-                        log_tx
-                            .send(WorkerMessage::Log(format!(
-                                "[ERROR] Failed to delete backup: {}",
-                                e
-                            )))
-                            .ok();
+                {
+                    let manager_read = manager.read().unwrap();
+                    match manager_read.delete_backup(&backup) {
+                        Ok(()) => {
+                            log_tx
+                                .send(WorkerMessage::Log("[SUCCESS] Backup deleted".to_string()))
+                                .ok();
+                        }
+                        Err(e) => {
+                            log_tx
+                                .send(WorkerMessage::Log(format!(
+                                    "[ERROR] Failed to delete backup: {}",
+                                    e
+                                )))
+                                .ok();
+                        }
                     }
                 }
                 // Refresh the backup list after deletion
-                match manager.list_backups() {
-                    Ok(backups) => {
-                        log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
-                    }
-                    Err(e) => {
-                        log_tx
-                            .send(WorkerMessage::Log(format!(
-                                "[ERROR] Failed to refresh backup list: {}",
-                                e
-                            )))
-                            .ok();
+                {
+                    let manager_read = manager.read().unwrap();
+                    match manager_read.list_backups() {
+                        Ok(backups) => {
+                            log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
+                        }
+                        Err(e) => {
+                            log_tx
+                                .send(WorkerMessage::Log(format!(
+                                    "[ERROR] Failed to refresh backup list: {}",
+                                    e
+                                )))
+                                .ok();
+                        }
                     }
                 }
             });

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,7 @@
 // Author: Jacques Murray
 //! Defines the TUI application state (App struct).
 
+use crate::core::diff::DiffResult;
 use crate::core::restore::BackupEntry;
 use crate::core::DotfileManager;
 use crossterm::event::KeyCode;
@@ -19,6 +20,8 @@ pub enum AppMode {
     Sync,
     /// Restore mode - browse and restore backups
     Restore,
+    /// Diff preview mode - view diffs before syncing
+    DiffPreview,
 }
 
 /// Messages sent from worker threads to the main UI thread.
@@ -27,6 +30,7 @@ pub enum WorkerMessage {
     SyncComplete,
     RestoreComplete,
     BackupsListed(Vec<BackupEntry>),
+    DiffGenerated(Vec<DiffResult>),
 }
 
 /// Represents the TUI's state and logic.
@@ -45,6 +49,9 @@ pub struct App {
     pub backups: Vec<BackupEntry>,
     pub selected_backup: Option<usize>,
     pub restore_in_progress: bool,
+    pub diffs: Vec<DiffResult>,
+    pub selected_diff: Option<usize>,
+    pub diff_scroll: u16,
     log_tx: mpsc::Sender<WorkerMessage>,
 }
 
@@ -68,7 +75,7 @@ impl App {
             logs: VecDeque::from([
                 "Welcome to the TUI Dotfile Manager!".to_string(),
                 "Use 'j'/'k' or Arrow Up/Down to select a profile.".to_string(),
-                "'s' = Sync, 'd' = Dry Run, 'r' = Restore Mode, 'q' = Quit.".to_string(),
+                "'s' = Sync, 'd' = Dry Run, 'p' = Diff Preview, 'r' = Restore Mode, 'q' = Quit.".to_string(),
             ]),
             should_quit: false,
             sync_in_progress: false,
@@ -76,6 +83,9 @@ impl App {
             backups: Vec::new(),
             selected_backup: None,
             restore_in_progress: false,
+            diffs: Vec::new(),
+            selected_diff: None,
+            diff_scroll: 0,
             log_tx,
         }
     }
@@ -88,6 +98,7 @@ impl App {
     /// * `k` or `Up` - Select previous profile
     /// * `s` or `Enter` - Start sync for selected profile
     /// * `d` - Start dry run for selected profile
+    /// * `p` - Preview diff for selected profile
     /// * `r` - Enter restore mode
     ///
     /// # Key Bindings (Restore Mode)
@@ -98,6 +109,13 @@ impl App {
     /// * `d` - Dry run restore for selected backup
     /// * `Delete` - Delete selected backup
     ///
+    /// # Key Bindings (Diff Preview Mode)
+    /// * `Esc` or `q` - Back to sync mode
+    /// * `j` or `Down` - Scroll down
+    /// * `k` or `Up` - Scroll up
+    /// * `n` - Next diff
+    /// * `N` - Previous diff
+    ///
     /// Input is ignored while a sync or restore operation is in progress.
     pub fn on_key(&mut self, key: KeyCode) {
         if self.sync_in_progress || self.restore_in_progress {
@@ -107,6 +125,7 @@ impl App {
         match self.mode {
             AppMode::Sync => self.handle_sync_mode_key(key),
             AppMode::Restore => self.handle_restore_mode_key(key),
+            AppMode::DiffPreview => self.handle_diff_mode_key(key),
         }
     }
 
@@ -118,6 +137,7 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => self.select_previous_profile(),
             KeyCode::Char('d') => self.start_sync(true),
             KeyCode::Char('s') | KeyCode::Enter => self.start_sync(false),
+            KeyCode::Char('p') => self.enter_diff_preview_mode(),
             KeyCode::Char('r') => self.enter_restore_mode(),
             _ => {}
         }
@@ -400,6 +420,102 @@ impl App {
         }
     }
 
+    /// Handles key presses in diff preview mode.
+    fn handle_diff_mode_key(&mut self, key: KeyCode) {
+        match key {
+            KeyCode::Esc | KeyCode::Char('q') => self.exit_diff_preview_mode(),
+            KeyCode::Char('j') | KeyCode::Down => self.scroll_diff_down(),
+            KeyCode::Char('k') | KeyCode::Up => self.scroll_diff_up(),
+            KeyCode::Char('n') => self.select_next_diff(),
+            KeyCode::Char('N') => self.select_previous_diff(),
+            _ => {}
+        }
+    }
+
+    /// Enters diff preview mode and generates diffs for the selected profile.
+    fn enter_diff_preview_mode(&mut self) {
+        if let Some(selected_index) = self.selected_profile {
+            let profile_name = self.profiles[selected_index].clone();
+            self.mode = AppMode::DiffPreview;
+            self.diff_scroll = 0;
+            self.logs.push_back("---".to_string());
+            self.logs
+                .push_back(format!("Generating diff preview for profile: {}", profile_name));
+
+            let manager = Arc::clone(&self.manager);
+            let log_tx = self.log_tx.clone();
+
+            // Spawn a thread to generate diffs
+            thread::spawn(move || match manager.preview_diff(&profile_name) {
+                Ok(diffs) => {
+                    log_tx.send(WorkerMessage::DiffGenerated(diffs)).ok();
+                }
+                Err(e) => {
+                    log_tx
+                        .send(WorkerMessage::Log(format!(
+                            "[ERROR] Failed to generate diff: {}",
+                            e
+                        )))
+                        .ok();
+                    log_tx.send(WorkerMessage::DiffGenerated(Vec::new())).ok();
+                }
+            });
+        } else {
+            self.logs
+                .push_back("[ERROR] No profile selected.".to_string());
+        }
+    }
+
+    /// Exits diff preview mode and returns to sync mode.
+    fn exit_diff_preview_mode(&mut self) {
+        self.mode = AppMode::Sync;
+        self.diffs.clear();
+        self.selected_diff = None;
+        self.diff_scroll = 0;
+        self.logs.push_back("---".to_string());
+        self.logs.push_back("Exited Diff Preview Mode".to_string());
+    }
+
+    /// Scrolls down in the diff view.
+    fn scroll_diff_down(&mut self) {
+        self.diff_scroll = self.diff_scroll.saturating_add(1);
+    }
+
+    /// Scrolls up in the diff view.
+    fn scroll_diff_up(&mut self) {
+        self.diff_scroll = self.diff_scroll.saturating_sub(1);
+    }
+
+    /// Selects the next diff in the list.
+    fn select_next_diff(&mut self) {
+        if self.diffs.is_empty() {
+            return;
+        }
+        let i = self.selected_diff.unwrap_or(0);
+        let next = if i >= self.diffs.len() - 1 {
+            0
+        } else {
+            i + 1
+        };
+        self.selected_diff = Some(next);
+        self.diff_scroll = 0; // Reset scroll when switching diffs
+    }
+
+    /// Selects the previous diff in the list.
+    fn select_previous_diff(&mut self) {
+        if self.diffs.is_empty() {
+            return;
+        }
+        let i = self.selected_diff.unwrap_or(0);
+        let prev = if i == 0 {
+            self.diffs.len() - 1
+        } else {
+            i - 1
+        };
+        self.selected_diff = Some(prev);
+        self.diff_scroll = 0; // Reset scroll when switching diffs
+    }
+
     /// Called when the app receives a new message from a worker thread.
     ///
     /// # Arguments
@@ -429,6 +545,12 @@ impl App {
                 self.backups = backups;
                 self.selected_backup = if count > 0 { Some(0) } else { None };
                 self.logs.push_back(format!("Found {} backup(s)", count));
+            }
+            WorkerMessage::DiffGenerated(diffs) => {
+                let count = diffs.len();
+                self.diffs = diffs;
+                self.selected_diff = if count > 0 { Some(0) } else { None };
+                self.logs.push_back(format!("Generated {} diff(s)", count));
             }
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -32,6 +32,16 @@ pub enum WorkerMessage {
     RestoreComplete,
     BackupsListed(Vec<BackupEntry>),
     DiffGenerated(Vec<DiffResult>),
+    SyncStarted { total_files: usize },
+    Progress { current: usize, total: usize, file: String },
+}
+
+/// Tracks sync progress for UI display.
+#[derive(Debug, Clone)]
+pub struct SyncProgress {
+    pub current: usize,
+    pub total: usize,
+    pub current_file: String,
 }
 
 /// Represents the TUI's state and logic.
@@ -574,18 +584,34 @@ impl App {
             let log_tx = self.log_tx.clone();
 
             // Spawn a thread to generate diffs
-            thread::spawn(move || match manager.preview_diff(&profile_name) {
-                Ok(diffs) => {
-                    log_tx.send(WorkerMessage::DiffGenerated(diffs)).ok();
-                }
-                Err(e) => {
-                    log_tx
-                        .send(WorkerMessage::Log(format!(
-                            "[ERROR] Failed to generate diff: {}",
-                            e
-                        )))
-                        .ok();
-                    log_tx.send(WorkerMessage::DiffGenerated(Vec::new())).ok();
+            thread::spawn(move || {
+                let manager_guard = match manager.read() {
+                    Ok(guard) => guard,
+                    Err(e) => {
+                        log_tx
+                            .send(WorkerMessage::Log(format!(
+                                "[ERROR] Failed to acquire manager lock: {}",
+                                e
+                            )))
+                            .ok();
+                        log_tx.send(WorkerMessage::DiffGenerated(Vec::new())).ok();
+                        return;
+                    }
+                };
+
+                match manager_guard.preview_diff(&profile_name) {
+                    Ok(diffs) => {
+                        log_tx.send(WorkerMessage::DiffGenerated(diffs)).ok();
+                    }
+                    Err(e) => {
+                        log_tx
+                            .send(WorkerMessage::Log(format!(
+                                "[ERROR] Failed to generate diff: {}",
+                                e
+                            )))
+                            .ok();
+                        log_tx.send(WorkerMessage::DiffGenerated(Vec::new())).ok();
+                    }
                 }
             });
         } else {
@@ -680,6 +706,20 @@ impl App {
                 self.diffs = diffs;
                 self.selected_diff = if count > 0 { Some(0) } else { None };
                 self.logs.push_back(format!("Generated {} diff(s)", count));
+            }
+            WorkerMessage::SyncStarted { total_files } => {
+                self.sync_progress = Some(SyncProgress {
+                    current: 0,
+                    total: total_files,
+                    current_file: String::new(),
+                });
+            }
+            WorkerMessage::Progress { current, total, file } => {
+                self.sync_progress = Some(SyncProgress {
+                    current,
+                    total,
+                    current_file: file,
+                });
             }
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -205,26 +205,23 @@ impl App {
         self.mode = AppMode::Restore;
         self.logs.push_back("---".to_string());
         self.logs.push_back("Entering Restore Mode...".to_string());
-        
+
         let manager = Arc::clone(&self.manager);
         let log_tx = self.log_tx.clone();
-        
+
         // Spawn a thread to list backups
-        thread::spawn(move || {
-            match manager.list_backups() {
-                Ok(backups) => {
-                    log_tx
-                        .send(WorkerMessage::BackupsListed(backups))
-                        .ok();
-                }
-                Err(e) => {
-                    log_tx
-                        .send(WorkerMessage::Log(format!("[ERROR] Failed to list backups: {}", e)))
-                        .ok();
-                    log_tx
-                        .send(WorkerMessage::BackupsListed(Vec::new()))
-                        .ok();
-                }
+        thread::spawn(move || match manager.list_backups() {
+            Ok(backups) => {
+                log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
+            }
+            Err(e) => {
+                log_tx
+                    .send(WorkerMessage::Log(format!(
+                        "[ERROR] Failed to list backups: {}",
+                        e
+                    )))
+                    .ok();
+                log_tx.send(WorkerMessage::BackupsListed(Vec::new())).ok();
             }
         });
     }
@@ -362,10 +359,8 @@ impl App {
             let log_tx = self.log_tx.clone();
 
             self.logs.push_back("---".to_string());
-            self.logs.push_back(format!(
-                "Deleting backup: {}",
-                backup.backup_path.display()
-            ));
+            self.logs
+                .push_back(format!("Deleting backup: {}", backup.backup_path.display()));
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
@@ -377,7 +372,10 @@ impl App {
                     }
                     Err(e) => {
                         log_tx
-                            .send(WorkerMessage::Log(format!("[ERROR] Failed to delete backup: {}", e)))
+                            .send(WorkerMessage::Log(format!(
+                                "[ERROR] Failed to delete backup: {}",
+                                e
+                            )))
                             .ok();
                     }
                 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -5,7 +5,8 @@ use crate::core::restore::BackupEntry;
 use crate::core::DotfileManager;
 use crossterm::event::KeyCode;
 use std::collections::VecDeque;
-use std::sync::{mpsc, Arc};
+use std::path::PathBuf;
+use std::sync::{mpsc, Arc, RwLock};
 use std::thread;
 
 /// Maximum number of log messages to keep in memory.
@@ -45,7 +46,8 @@ pub struct SyncProgress {
 /// log messages, and sync status. It handles user input and coordinates with
 /// background worker threads for I/O operations.
 pub struct App {
-    pub manager: Arc<DotfileManager>,
+    pub manager: Arc<RwLock<DotfileManager>>,
+    pub config_path: PathBuf,
     pub profiles: Vec<String>,
     pub selected_profile: Option<usize>,
     pub logs: VecDeque<String>,
@@ -64,22 +66,28 @@ impl App {
     ///
     /// # Arguments
     /// * `manager` - Shared reference to the DotfileManager
+    /// * `config_path` - Path to the configuration file for reloading
     /// * `log_tx` - Channel sender for receiving log messages from worker threads
     ///
     /// # Returns
     /// A new App instance with initial welcome messages and the first profile selected.
-    pub fn new(manager: Arc<DotfileManager>, log_tx: mpsc::Sender<WorkerMessage>) -> Self {
-        let profiles = manager.get_profiles();
+    pub fn new(
+        manager: Arc<RwLock<DotfileManager>>,
+        config_path: PathBuf,
+        log_tx: mpsc::Sender<WorkerMessage>,
+    ) -> Self {
+        let profiles = manager.read().unwrap().get_profiles();
         let selected_profile = if profiles.is_empty() { None } else { Some(0) };
 
         Self {
             manager,
+            config_path,
             profiles,
             selected_profile,
             logs: VecDeque::from([
                 "Welcome to the TUI Dotfile Manager!".to_string(),
                 "Use 'j'/'k' or Arrow Up/Down to select a profile.".to_string(),
-                "'s' = Sync, 'd' = Dry Run, 'r' = Restore Mode, 'q' = Quit.".to_string(),
+                "'s' = Sync, 'd' = Dry Run, 'R' = Reload Config, 'r' = Restore Mode, 'q' = Quit.".to_string(),
             ]),
             should_quit: false,
             sync_in_progress: false,
@@ -130,6 +138,7 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => self.select_previous_profile(),
             KeyCode::Char('d') => self.start_sync(true),
             KeyCode::Char('s') | KeyCode::Enter => self.start_sync(false),
+            KeyCode::Char('R') => self.reload_config(),
             KeyCode::Char('r') => self.enter_restore_mode(),
             _ => {}
         }
@@ -222,18 +231,24 @@ impl App {
         let log_tx = self.log_tx.clone();
 
         // Spawn a thread to list backups
-        thread::spawn(move || match manager.list_backups() {
-            Ok(backups) => {
-                log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
-            }
-            Err(e) => {
-                log_tx
-                    .send(WorkerMessage::Log(format!(
-                        "[ERROR] Failed to list backups: {}",
-                        e
-                    )))
-                    .ok();
-                log_tx.send(WorkerMessage::BackupsListed(Vec::new())).ok();
+        thread::spawn(move || {
+            let result = {
+                let manager_read = manager.read().unwrap();
+                manager_read.list_backups()
+            };
+            match result {
+                Ok(backups) => {
+                    log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
+                }
+                Err(e) => {
+                    log_tx
+                        .send(WorkerMessage::Log(format!(
+                            "[ERROR] Failed to list backups: {}",
+                            e
+                        )))
+                        .ok();
+                    log_tx.send(WorkerMessage::BackupsListed(Vec::new())).ok();
+                }
             }
         });
     }
@@ -245,6 +260,90 @@ impl App {
         self.selected_backup = None;
         self.logs.push_back("---".to_string());
         self.logs.push_back("Exited Restore Mode".to_string());
+    }
+
+    /// Reloads the configuration file and updates the profile list.
+    ///
+    /// This method:
+    /// - Re-reads and parses the config file
+    /// - Updates the profile list
+    /// - Adjusts profile selection if needed
+    /// - Provides user feedback
+    /// - Handles errors gracefully without crashing
+    fn reload_config(&mut self) {
+        if self.sync_in_progress {
+            self.logs.push_back("---".to_string());
+            self.logs
+                .push_back("[WARN] Cannot reload config during sync.".to_string());
+            return;
+        }
+
+        if self.restore_in_progress {
+            self.logs.push_back("---".to_string());
+            self.logs
+                .push_back("[WARN] Cannot reload config during restore.".to_string());
+            return;
+        }
+
+        self.logs.push_back("---".to_string());
+        self.logs
+            .push_back("Reloading configuration...".to_string());
+
+        // Attempt to reload the configuration
+        let result = {
+            let mut manager = self.manager.write().unwrap();
+            manager.reload_config(&self.config_path)
+        };
+
+        match result {
+            Ok(()) => {
+                // Update profile list
+                let old_profiles = std::mem::take(&mut self.profiles);
+                self.profiles = self.manager.read().unwrap().get_profiles();
+
+                // Handle selection adjustment
+                let old_selected_name = self
+                    .selected_profile
+                    .and_then(|idx| old_profiles.get(idx))
+                    .cloned();
+
+                if let Some(old_name) = old_selected_name {
+                    // Try to find the previously selected profile in the new list
+                    self.selected_profile = self
+                        .profiles
+                        .iter()
+                        .position(|name| name == &old_name)
+                        .or_else(|| {
+                            if !self.profiles.is_empty() {
+                                self.logs.push_back(format!(
+                                    "[INFO] Profile '{}' no longer exists. Switched to '{}'.",
+                                    old_name, self.profiles[0]
+                                ));
+                                Some(0)
+                            } else {
+                                None
+                            }
+                        });
+                } else if !self.profiles.is_empty() {
+                    self.selected_profile = Some(0);
+                } else {
+                    self.selected_profile = None;
+                }
+
+                // Success message
+                self.logs.push_back(format!(
+                    "[SUCCESS] Configuration reloaded. {} profile(s) available.",
+                    self.profiles.len()
+                ));
+            }
+            Err(e) => {
+                // Error handling - don't crash, just log the error
+                self.logs
+                    .push_back(format!("[ERROR] Failed to reload configuration: {}", e));
+                self.logs
+                    .push_back("[INFO] Using previous configuration.".to_string());
+            }
+        }
     }
 
     /// Spawns a worker thread to perform the sync.
@@ -273,20 +372,25 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                // Get the total number of files
-                let total_files = manager.get_profile_link_count(&profile_name);
+                let result = {
+                    let manager_read = manager.read().unwrap();
+                    
+                    // Get the total number of files
+                    let total_files = manager_read.get_profile_link_count(&profile_name);
 
-                // Send sync started message
-                log_tx.send(WorkerMessage::SyncStarted { total_files }).ok();
+                    // Send sync started message
+                    log_tx.send(WorkerMessage::SyncStarted { total_files }).ok();
 
-                // Execute sync with progress callback
-                match manager.execute_sync_with_progress(&profile_name, dry_run, |current, total, file| {
-                    log_tx.send(WorkerMessage::Progress {
-                        current,
-                        total,
-                        file: file.to_string(),
-                    }).ok();
-                }) {
+                    // Execute sync with progress callback
+                    manager_read.execute_sync_with_progress(&profile_name, dry_run, |current, total, file| {
+                        log_tx.send(WorkerMessage::Progress {
+                            current,
+                            total,
+                            file: file.to_string(),
+                        }).ok();
+                    })
+                };
+                match result {
                     Ok(logs) => {
                         for log in logs {
                             log_tx.send(WorkerMessage::Log(log)).ok();
@@ -343,7 +447,11 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                match manager.restore_backup(&backup, dry_run) {
+                let result = {
+                    let manager_read = manager.read().unwrap();
+                    manager_read.restore_backup(&backup, dry_run)
+                };
+                match result {
                     Ok(logs) => {
                         for log in logs {
                             log_tx.send(WorkerMessage::Log(log)).ok();
@@ -389,33 +497,39 @@ impl App {
 
             // Spawn the blocking I/O in a separate thread
             thread::spawn(move || {
-                match manager.delete_backup(&backup) {
-                    Ok(()) => {
-                        log_tx
-                            .send(WorkerMessage::Log("[SUCCESS] Backup deleted".to_string()))
-                            .ok();
-                    }
-                    Err(e) => {
-                        log_tx
-                            .send(WorkerMessage::Log(format!(
-                                "[ERROR] Failed to delete backup: {}",
-                                e
-                            )))
-                            .ok();
+                {
+                    let manager_read = manager.read().unwrap();
+                    match manager_read.delete_backup(&backup) {
+                        Ok(()) => {
+                            log_tx
+                                .send(WorkerMessage::Log("[SUCCESS] Backup deleted".to_string()))
+                                .ok();
+                        }
+                        Err(e) => {
+                            log_tx
+                                .send(WorkerMessage::Log(format!(
+                                    "[ERROR] Failed to delete backup: {}",
+                                    e
+                                )))
+                                .ok();
+                        }
                     }
                 }
                 // Refresh the backup list after deletion
-                match manager.list_backups() {
-                    Ok(backups) => {
-                        log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
-                    }
-                    Err(e) => {
-                        log_tx
-                            .send(WorkerMessage::Log(format!(
-                                "[ERROR] Failed to refresh backup list: {}",
-                                e
-                            )))
-                            .ok();
+                {
+                    let manager_read = manager.read().unwrap();
+                    match manager_read.list_backups() {
+                        Ok(backups) => {
+                            log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
+                        }
+                        Err(e) => {
+                            log_tx
+                                .send(WorkerMessage::Log(format!(
+                                    "[ERROR] Failed to refresh backup list: {}",
+                                    e
+                                )))
+                                .ok();
+                        }
                     }
                 }
             });

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,6 +1,7 @@
 // Author: Jacques Murray
 //! Defines the TUI application state (App struct).
 
+use crate::core::restore::BackupEntry;
 use crate::core::DotfileManager;
 use crossterm::event::KeyCode;
 use std::collections::VecDeque;
@@ -11,10 +12,21 @@ use std::thread;
 /// Older messages are removed to prevent unbounded memory growth.
 const MAX_LOG_MESSAGES: usize = 1000;
 
+/// Application operating modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppMode {
+    /// Sync mode - select and sync profiles
+    Sync,
+    /// Restore mode - browse and restore backups
+    Restore,
+}
+
 /// Messages sent from worker threads to the main UI thread.
 pub enum WorkerMessage {
     Log(String),
     SyncComplete,
+    RestoreComplete,
+    BackupsListed(Vec<BackupEntry>),
 }
 
 /// Represents the TUI's state and logic.
@@ -29,6 +41,10 @@ pub struct App {
     pub logs: VecDeque<String>,
     pub should_quit: bool,
     pub sync_in_progress: bool,
+    pub mode: AppMode,
+    pub backups: Vec<BackupEntry>,
+    pub selected_backup: Option<usize>,
+    pub restore_in_progress: bool,
     log_tx: mpsc::Sender<WorkerMessage>,
 }
 
@@ -52,35 +68,70 @@ impl App {
             logs: VecDeque::from([
                 "Welcome to the TUI Dotfile Manager!".to_string(),
                 "Use 'j'/'k' or Arrow Up/Down to select a profile.".to_string(),
-                "'s' = Sync, 'd' = Dry Run, 'q' = Quit.".to_string(),
+                "'s' = Sync, 'd' = Dry Run, 'r' = Restore Mode, 'q' = Quit.".to_string(),
             ]),
             should_quit: false,
             sync_in_progress: false,
+            mode: AppMode::Sync,
+            backups: Vec::new(),
+            selected_backup: None,
+            restore_in_progress: false,
             log_tx,
         }
     }
 
     /// Handles a key press event.
     ///
-    /// # Key Bindings
+    /// # Key Bindings (Sync Mode)
     /// * `q` or `Esc` - Quit the application
     /// * `j` or `Down` - Select next profile
     /// * `k` or `Up` - Select previous profile
     /// * `s` or `Enter` - Start sync for selected profile
     /// * `d` - Start dry run for selected profile
+    /// * `r` - Enter restore mode
     ///
-    /// Input is ignored while a sync operation is in progress.
+    /// # Key Bindings (Restore Mode)
+    /// * `Esc` or `b` - Back to sync mode
+    /// * `j` or `Down` - Select next backup
+    /// * `k` or `Up` - Select previous backup
+    /// * `r` or `Enter` - Restore selected backup
+    /// * `d` - Dry run restore for selected backup
+    /// * `Delete` - Delete selected backup
+    ///
+    /// Input is ignored while a sync or restore operation is in progress.
     pub fn on_key(&mut self, key: KeyCode) {
-        if self.sync_in_progress {
+        if self.sync_in_progress || self.restore_in_progress {
             return;
         }
 
+        match self.mode {
+            AppMode::Sync => self.handle_sync_mode_key(key),
+            AppMode::Restore => self.handle_restore_mode_key(key),
+        }
+    }
+
+    /// Handles key presses in sync mode.
+    fn handle_sync_mode_key(&mut self, key: KeyCode) {
         match key {
             KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
-            KeyCode::Char('j') | KeyCode::Down => self.select_next(),
-            KeyCode::Char('k') | KeyCode::Up => self.select_previous(),
+            KeyCode::Char('j') | KeyCode::Down => self.select_next_profile(),
+            KeyCode::Char('k') | KeyCode::Up => self.select_previous_profile(),
             KeyCode::Char('d') => self.start_sync(true),
             KeyCode::Char('s') | KeyCode::Enter => self.start_sync(false),
+            KeyCode::Char('r') => self.enter_restore_mode(),
+            _ => {}
+        }
+    }
+
+    /// Handles key presses in restore mode.
+    fn handle_restore_mode_key(&mut self, key: KeyCode) {
+        match key {
+            KeyCode::Esc | KeyCode::Char('b') => self.exit_restore_mode(),
+            KeyCode::Char('j') | KeyCode::Down => self.select_next_backup(),
+            KeyCode::Char('k') | KeyCode::Up => self.select_previous_backup(),
+            KeyCode::Char('r') | KeyCode::Enter => self.start_restore(false),
+            KeyCode::Char('d') => self.start_restore(true),
+            KeyCode::Delete => self.delete_selected_backup(),
             _ => {}
         }
     }
@@ -88,7 +139,7 @@ impl App {
     /// Selects the next profile in the list.
     ///
     /// Wraps around to the first profile when reaching the end.
-    fn select_next(&mut self) {
+    fn select_next_profile(&mut self) {
         if self.profiles.is_empty() {
             return;
         }
@@ -104,7 +155,7 @@ impl App {
     /// Selects the previous profile in the list.
     ///
     /// Wraps around to the last profile when at the beginning.
-    fn select_previous(&mut self) {
+    fn select_previous_profile(&mut self) {
         if self.profiles.is_empty() {
             return;
         }
@@ -115,6 +166,76 @@ impl App {
             i - 1
         };
         self.selected_profile = Some(prev);
+    }
+
+    /// Selects the next backup in the list.
+    ///
+    /// Wraps around to the first backup when reaching the end.
+    fn select_next_backup(&mut self) {
+        if self.backups.is_empty() {
+            return;
+        }
+        let i = self.selected_backup.unwrap_or(0);
+        let next = if i >= self.backups.len() - 1 {
+            0
+        } else {
+            i + 1
+        };
+        self.selected_backup = Some(next);
+    }
+
+    /// Selects the previous backup in the list.
+    ///
+    /// Wraps around to the last backup when at the beginning.
+    fn select_previous_backup(&mut self) {
+        if self.backups.is_empty() {
+            return;
+        }
+        let i = self.selected_backup.unwrap_or(0);
+        let prev = if i == 0 {
+            self.backups.len() - 1
+        } else {
+            i - 1
+        };
+        self.selected_backup = Some(prev);
+    }
+
+    /// Enters restore mode and loads the list of backups.
+    fn enter_restore_mode(&mut self) {
+        self.mode = AppMode::Restore;
+        self.logs.push_back("---".to_string());
+        self.logs.push_back("Entering Restore Mode...".to_string());
+        
+        let manager = Arc::clone(&self.manager);
+        let log_tx = self.log_tx.clone();
+        
+        // Spawn a thread to list backups
+        thread::spawn(move || {
+            match manager.list_backups() {
+                Ok(backups) => {
+                    log_tx
+                        .send(WorkerMessage::BackupsListed(backups))
+                        .ok();
+                }
+                Err(e) => {
+                    log_tx
+                        .send(WorkerMessage::Log(format!("[ERROR] Failed to list backups: {}", e)))
+                        .ok();
+                    log_tx
+                        .send(WorkerMessage::BackupsListed(Vec::new()))
+                        .ok();
+                }
+            }
+        });
+    }
+
+    /// Exits restore mode and returns to sync mode.
+    fn exit_restore_mode(&mut self) {
+        self.mode = AppMode::Sync;
+        self.backups.clear();
+        self.selected_backup = None;
+        self.logs.push_back("---".to_string());
+        self.logs.push_back("Exited Restore Mode".to_string());
     }
 
     /// Spawns a worker thread to perform the sync.
@@ -164,6 +285,123 @@ impl App {
         }
     }
 
+    /// Spawns a worker thread to restore a backup.
+    ///
+    /// # Arguments
+    /// * `dry_run` - If true, performs a dry run without making changes
+    ///
+    /// The restore operation runs in a background thread to keep the UI responsive.
+    /// Log messages are sent back via the log channel.
+    fn start_restore(&mut self, dry_run: bool) {
+        if self.restore_in_progress {
+            return;
+        }
+
+        if let Some(selected_index) = self.selected_backup {
+            if selected_index >= self.backups.len() {
+                self.logs
+                    .push_back("[ERROR] Invalid backup selection.".to_string());
+                return;
+            }
+
+            self.restore_in_progress = true;
+            let backup = self.backups[selected_index].clone();
+            let manager = Arc::clone(&self.manager);
+            let log_tx = self.log_tx.clone();
+
+            self.logs.push_back("---".to_string());
+            self.logs.push_back(format!(
+                "Starting {}...",
+                if dry_run {
+                    "Restore Dry Run"
+                } else {
+                    "Restore"
+                }
+            ));
+
+            // Spawn the blocking I/O in a separate thread
+            thread::spawn(move || {
+                match manager.restore_backup(&backup, dry_run) {
+                    Ok(logs) => {
+                        for log in logs {
+                            log_tx.send(WorkerMessage::Log(log)).ok();
+                        }
+                    }
+                    Err(e) => {
+                        log_tx
+                            .send(WorkerMessage::Log(format!("[FATAL ERROR] {}", e)))
+                            .ok();
+                    }
+                }
+                // Send a signal that the thread is done
+                log_tx.send(WorkerMessage::RestoreComplete).ok();
+            });
+        } else {
+            self.logs
+                .push_back("[ERROR] No backup selected.".to_string());
+        }
+    }
+
+    /// Deletes the selected backup file.
+    ///
+    /// This operation runs in a background thread.
+    fn delete_selected_backup(&mut self) {
+        if self.restore_in_progress {
+            return;
+        }
+
+        if let Some(selected_index) = self.selected_backup {
+            if selected_index >= self.backups.len() {
+                self.logs
+                    .push_back("[ERROR] Invalid backup selection.".to_string());
+                return;
+            }
+
+            let backup = self.backups[selected_index].clone();
+            let manager = Arc::clone(&self.manager);
+            let log_tx = self.log_tx.clone();
+
+            self.logs.push_back("---".to_string());
+            self.logs.push_back(format!(
+                "Deleting backup: {}",
+                backup.backup_path.display()
+            ));
+
+            // Spawn the blocking I/O in a separate thread
+            thread::spawn(move || {
+                match manager.delete_backup(&backup) {
+                    Ok(()) => {
+                        log_tx
+                            .send(WorkerMessage::Log("[SUCCESS] Backup deleted".to_string()))
+                            .ok();
+                    }
+                    Err(e) => {
+                        log_tx
+                            .send(WorkerMessage::Log(format!("[ERROR] Failed to delete backup: {}", e)))
+                            .ok();
+                    }
+                }
+                // Refresh the backup list after deletion
+                match manager.list_backups() {
+                    Ok(backups) => {
+                        log_tx.send(WorkerMessage::BackupsListed(backups)).ok();
+                    }
+                    Err(e) => {
+                        log_tx
+                            .send(WorkerMessage::Log(format!(
+                                "[ERROR] Failed to refresh backup list: {}",
+                                e
+                            )))
+                            .ok();
+                    }
+                }
+            });
+        } else {
+            self.logs
+                .push_back("[ERROR] No backup selected.".to_string());
+        }
+    }
+
     /// Called when the app receives a new message from a worker thread.
     ///
     /// # Arguments
@@ -182,6 +420,17 @@ impl App {
             }
             WorkerMessage::SyncComplete => {
                 self.sync_in_progress = false;
+            }
+            WorkerMessage::RestoreComplete => {
+                self.restore_in_progress = false;
+                // Refresh backup list after restore
+                self.enter_restore_mode();
+            }
+            WorkerMessage::BackupsListed(backups) => {
+                let count = backups.len();
+                self.backups = backups;
+                self.selected_backup = if count > 0 { Some(0) } else { None };
+                self.logs.push_back(format!("Found {} backup(s)", count));
             }
         }
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -18,7 +18,7 @@ pub enum WorkerMessage {
 }
 
 /// Represents the TUI's state and logic.
-/// 
+///
 /// The App struct maintains the application state including the selected profile,
 /// log messages, and sync status. It handles user input and coordinates with
 /// background worker threads for I/O operations.
@@ -34,11 +34,11 @@ pub struct App {
 
 impl App {
     /// Creates a new App.
-    /// 
+    ///
     /// # Arguments
     /// * `manager` - Shared reference to the DotfileManager
     /// * `log_tx` - Channel sender for receiving log messages from worker threads
-    /// 
+    ///
     /// # Returns
     /// A new App instance with initial welcome messages and the first profile selected.
     pub fn new(manager: Arc<DotfileManager>, log_tx: mpsc::Sender<WorkerMessage>) -> Self {
@@ -61,14 +61,14 @@ impl App {
     }
 
     /// Handles a key press event.
-    /// 
+    ///
     /// # Key Bindings
     /// * `q` or `Esc` - Quit the application
     /// * `j` or `Down` - Select next profile
     /// * `k` or `Up` - Select previous profile
     /// * `s` or `Enter` - Start sync for selected profile
     /// * `d` - Start dry run for selected profile
-    /// 
+    ///
     /// Input is ignored while a sync operation is in progress.
     pub fn on_key(&mut self, key: KeyCode) {
         if self.sync_in_progress {
@@ -86,7 +86,7 @@ impl App {
     }
 
     /// Selects the next profile in the list.
-    /// 
+    ///
     /// Wraps around to the first profile when reaching the end.
     fn select_next(&mut self) {
         if self.profiles.is_empty() {
@@ -102,7 +102,7 @@ impl App {
     }
 
     /// Selects the previous profile in the list.
-    /// 
+    ///
     /// Wraps around to the last profile when at the beginning.
     fn select_previous(&mut self) {
         if self.profiles.is_empty() {
@@ -118,10 +118,10 @@ impl App {
     }
 
     /// Spawns a worker thread to perform the sync.
-    /// 
+    ///
     /// # Arguments
     /// * `dry_run` - If true, performs a dry run without making changes
-    /// 
+    ///
     /// The sync operation runs in a background thread to keep the UI responsive.
     /// Log messages are sent back via the log channel.
     fn start_sync(&mut self, dry_run: bool) {
@@ -150,22 +150,25 @@ impl App {
                         }
                     }
                     Err(e) => {
-                        log_tx.send(WorkerMessage::Log(format!("[FATAL ERROR] {}", e))).ok();
+                        log_tx
+                            .send(WorkerMessage::Log(format!("[FATAL ERROR] {}", e)))
+                            .ok();
                     }
                 }
                 // Send a signal that the thread is done
                 log_tx.send(WorkerMessage::SyncComplete).ok();
             });
         } else {
-            self.logs.push_back("[ERROR] No profile selected.".to_string());
+            self.logs
+                .push_back("[ERROR] No profile selected.".to_string());
         }
     }
 
     /// Called when the app receives a new message from a worker thread.
-    /// 
+    ///
     /// # Arguments
     /// * `msg` - The message received from a worker thread
-    /// 
+    ///
     /// Handles log messages and sync completion signals.
     /// Implements log rotation to prevent unbounded memory growth.
     pub fn on_log(&mut self, msg: WorkerMessage) {

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -22,13 +22,13 @@ pub enum Event {
 }
 
 /// Runs the event listener in a separate thread.
-/// 
+///
 /// Sends events back to the main loop via a channel. This includes keyboard
 /// input and periodic tick events for UI updates.
-/// 
+///
 /// # Arguments
 /// * `tx` - Channel sender for transmitting events to the main thread
-/// 
+///
 /// # Errors
 /// Returns an error if the thread cannot be spawned (rare).
 /// Runtime errors in the event thread are sent as Event::Error variants.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -66,7 +66,24 @@ fn render_restore_view(f: &mut Frame, app: &App) {
 ///
 /// Displays different content when a sync is in progress.
 fn render_sync_help(f: &mut Frame, app: &App, area: Rect) {
-    let text = if app.sync_in_progress {
+    let text = if let Some(progress) = &app.sync_progress {
+        // Show progress bar and stats
+        let percentage = if progress.total > 0 {
+            (progress.current as f64 / progress.total as f64 * 100.0) as u16
+        } else {
+            0
+        };
+        Line::from(vec![
+            Span::styled(
+                "SYNC: ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!("{}/{} ({}%) - ", progress.current, progress.total, percentage)),
+            Span::styled(&progress.current_file, Style::default().fg(Color::Cyan)),
+        ])
+    } else if app.sync_in_progress {
         Line::from(vec![
             Span::styled(
                 "SYNC IN PROGRESS...",
@@ -74,7 +91,7 @@ fn render_sync_help(f: &mut Frame, app: &App, area: Rect) {
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Please wait."),
+            Span::raw(" Please wait."),
         ])
     } else {
         Line::from(vec![

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -124,6 +124,13 @@ fn render_sync_help(f: &mut Frame, app: &App, area: Rect) {
             ),
             Span::raw("Dry Run"),
             Span::styled(
+                "  (R) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Reload Config"),
+            Span::styled(
                 "  (r) ",
                 Style::default()
                     .fg(Color::Cyan)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -165,7 +165,11 @@ fn render_restore_help(f: &mut Frame, app: &App, area: Rect) {
         ])
     };
 
-    let help = Paragraph::new(text).block(Block::default().title(" Help - Restore Mode ").borders(Borders::ALL));
+    let help = Paragraph::new(text).block(
+        Block::default()
+            .title(" Help - Restore Mode ")
+            .borders(Borders::ALL),
+    );
     f.render_widget(help, area);
 }
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,7 +1,7 @@
 // Author: Jacques Murray
 //! TUI rendering logic.
 
-use super::app::App;
+use super::app::{App, AppMode};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
@@ -19,9 +19,17 @@ const LOG_PERCENTAGE: u16 = 70;
 ///
 /// The UI is divided into three sections:
 /// 1. Help bar showing available commands
-/// 2. Profile list for selection
+/// 2. Profile list for selection (sync mode) or backup list (restore mode)
 /// 3. Log output showing sync operations and messages
 pub fn render(f: &mut Frame, app: &App) {
+    match app.mode {
+        AppMode::Sync => render_sync_view(f, app),
+        AppMode::Restore => render_restore_view(f, app),
+    }
+}
+
+/// Renders the sync view with profiles.
+fn render_sync_view(f: &mut Frame, app: &App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -31,15 +39,33 @@ pub fn render(f: &mut Frame, app: &App) {
         ])
         .split(f.size());
 
-    render_help(f, app, chunks[0]);
+    render_sync_help(f, app, chunks[0]);
     render_profile_list(f, app, chunks[1]);
     render_log_output(f, app, chunks[2]);
 }
 
-/// Renders the help bar showing available key bindings.
+/// Renders the restore view with backups and preview.
+fn render_restore_view(f: &mut Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(HELP_HEIGHT),
+            Constraint::Min(MIN_PROFILE_HEIGHT),
+            Constraint::Min(10),
+            Constraint::Percentage(LOG_PERCENTAGE),
+        ])
+        .split(f.size());
+
+    render_restore_help(f, app, chunks[0]);
+    render_backup_list(f, app, chunks[1]);
+    render_backup_preview(f, app, chunks[2]);
+    render_log_output(f, app, chunks[3]);
+}
+
+/// Renders the help bar showing available key bindings for sync mode.
 ///
 /// Displays different content when a sync is in progress.
-fn render_help(f: &mut Frame, app: &App, area: Rect) {
+fn render_sync_help(f: &mut Frame, app: &App, area: Rect) {
     let text = if app.sync_in_progress {
         Line::from(vec![
             Span::styled(
@@ -80,10 +106,66 @@ fn render_help(f: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw("Dry Run"),
+            Span::styled(
+                "  (r) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Restore Mode"),
         ])
     };
 
     let help = Paragraph::new(text).block(Block::default().title(" Help ").borders(Borders::ALL));
+    f.render_widget(help, area);
+}
+
+/// Renders the help bar showing available key bindings for restore mode.
+fn render_restore_help(f: &mut Frame, app: &App, area: Rect) {
+    let text = if app.restore_in_progress {
+        Line::from(vec![
+            Span::styled(
+                "RESTORE IN PROGRESS...",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Please wait."),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(
+                "  (r) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Restore"),
+            Span::styled(
+                "  (d) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Dry Run"),
+            Span::styled(
+                "  (Del) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Delete"),
+            Span::styled(
+                "  (b) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Back"),
+        ])
+    };
+
+    let help = Paragraph::new(text).block(Block::default().title(" Help - Restore Mode ").borders(Borders::ALL));
     f.render_widget(help, area);
 }
 
@@ -110,6 +192,81 @@ fn render_profile_list(f: &mut Frame, app: &App, area: Rect) {
     state.select(app.selected_profile);
 
     f.render_stateful_widget(list, area, &mut state);
+}
+
+/// Renders the backup list with the current selection highlighted.
+fn render_backup_list(f: &mut Frame, app: &App, area: Rect) {
+    let items: Vec<ListItem> = app
+        .backups
+        .iter()
+        .map(|backup| {
+            let display_text = format!(
+                "{} - {}",
+                backup.original_name,
+                backup.timestamp.format("%Y-%m-%d %H:%M:%S")
+            );
+            ListItem::new(display_text)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().title(" Backups ").borders(Borders::ALL))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::LightGreen)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    // Create a ListState to manage the selection
+    let mut state = ListState::default();
+    state.select(app.selected_backup);
+
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+/// Renders the preview panel for the selected backup.
+fn render_backup_preview(f: &mut Frame, app: &App, area: Rect) {
+    let text = if let Some(selected_index) = app.selected_backup {
+        if let Some(backup) = app.backups.get(selected_index) {
+            let mut lines = vec![
+                Line::from(format!("Original: {}", backup.original_name)),
+                Line::from(format!("Target: {}", backup.target_path.display())),
+                Line::from(format!(
+                    "Timestamp: {}",
+                    backup.timestamp.format("%Y-%m-%d %H:%M:%S")
+                )),
+                Line::from(format!("Size: {}", backup.format_size())),
+                Line::from(""),
+                Line::from("Content Preview:"),
+            ];
+
+            // Try to read first few lines of the backup
+            match backup.preview_content(5) {
+                Ok(preview_lines) => {
+                    for line in preview_lines {
+                        lines.push(Line::from(line));
+                    }
+                }
+                Err(_) => {
+                    lines.push(Line::from("[Binary file or read error]"));
+                }
+            }
+
+            lines
+        } else {
+            vec![Line::from("No backup selected")]
+        }
+    } else {
+        vec![Line::from("No backup selected")]
+    };
+
+    let preview = Paragraph::new(text)
+        .block(Block::default().title(" Preview ").borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+
+    f.render_widget(preview, area);
 }
 
 /// Renders the log output panel with auto-scrolling.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2,6 +2,7 @@
 //! TUI rendering logic.
 
 use super::app::{App, AppMode};
+use crate::core::diff::{DiffLineTag, DiffResult};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
@@ -25,6 +26,7 @@ pub fn render(f: &mut Frame, app: &App) {
     match app.mode {
         AppMode::Sync => render_sync_view(f, app),
         AppMode::Restore => render_restore_view(f, app),
+        AppMode::DiffPreview => render_diff_preview_view(f, app),
     }
 }
 
@@ -292,4 +294,170 @@ fn render_log_output(f: &mut Frame, app: &App, area: Rect) {
         )); // Auto-scroll to bottom
 
     f.render_widget(log_paragraph, area);
+}
+
+/// Renders the diff preview view.
+fn render_diff_preview_view(f: &mut Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(HELP_HEIGHT),
+            Constraint::Min(10),
+            Constraint::Percentage(30),
+        ])
+        .split(f.size());
+
+    render_diff_help(f, app, chunks[0]);
+    render_diff_content(f, app, chunks[1]);
+    render_log_output(f, app, chunks[2]);
+}
+
+/// Renders the help bar for diff preview mode.
+fn render_diff_help(f: &mut Frame, _app: &App, area: Rect) {
+    let text = Line::from(vec![
+        Span::styled(
+            "  (q) ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("Back"),
+        Span::styled(
+            "  (j/k) ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("Scroll"),
+        Span::styled(
+            "  (n/N) ",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("Next/Prev Diff"),
+    ]);
+
+    let help = Paragraph::new(text).block(
+        Block::default()
+            .title(" Help - Diff Preview Mode ")
+            .borders(Borders::ALL),
+    );
+    f.render_widget(help, area);
+}
+
+/// Renders the diff content panel.
+fn render_diff_content(f: &mut Frame, app: &App, area: Rect) {
+    if app.diffs.is_empty() {
+        let text = vec![Line::from("No diffs generated yet...")];
+        let paragraph = Paragraph::new(text)
+            .block(Block::default().title(" Diff Preview ").borders(Borders::ALL))
+            .wrap(Wrap { trim: true });
+        f.render_widget(paragraph, area);
+        return;
+    }
+
+    let selected_index = app.selected_diff.unwrap_or(0);
+    if selected_index >= app.diffs.len() {
+        return;
+    }
+
+    let diff = &app.diffs[selected_index];
+    let mut lines = Vec::new();
+
+    // Add header with file info
+    let title = format!(
+        " Diff {}/{}: {} ",
+        selected_index + 1,
+        app.diffs.len(),
+        diff.target_path().display()
+    );
+
+    // Build diff content
+    match diff {
+        DiffResult::NoDiff { reason, .. } => {
+            lines.push(Line::from(vec![
+                Span::styled("ℹ ", Style::default().fg(Color::Blue)),
+                Span::raw(reason),
+            ]));
+        }
+        DiffResult::FileDiff { diff_lines, .. } => {
+            for diff_line in diff_lines {
+                let line = match diff_line.tag {
+                    DiffLineTag::Insert => Line::from(vec![
+                        Span::styled(
+                            "+ ",
+                            Style::default()
+                                .fg(Color::Green)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(&diff_line.content, Style::default().fg(Color::Green)),
+                    ]),
+                    DiffLineTag::Delete => Line::from(vec![
+                        Span::styled(
+                            "- ",
+                            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(&diff_line.content, Style::default().fg(Color::Red)),
+                    ]),
+                    DiffLineTag::Equal => Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(&diff_line.content, Style::default().fg(Color::Gray)),
+                    ]),
+                };
+                lines.push(line);
+            }
+        }
+        DiffResult::NewFile {
+            content_preview, ..
+        } => {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "✨ New file will be created",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]));
+            lines.push(Line::from(""));
+            lines.push(Line::from("Content preview:"));
+            for (i, line) in content_preview.iter().enumerate() {
+                if i >= 50 {
+                    lines.push(Line::from(format!(
+                        "... ({} more lines)",
+                        content_preview.len() - i
+                    )));
+                    break;
+                }
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        "+ ",
+                        Style::default()
+                            .fg(Color::Green)
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(line, Style::default().fg(Color::Green)),
+                ]));
+            }
+        }
+        DiffResult::BinaryFile { .. } => {
+            lines.push(Line::from(vec![
+                Span::styled("⚠ ", Style::default().fg(Color::Yellow)),
+                Span::raw("Binary file - cannot show diff"),
+            ]));
+        }
+        DiffResult::Error { error, .. } => {
+            lines.push(Line::from(vec![
+                Span::styled("✗ ", Style::default().fg(Color::Red)),
+                Span::styled(format!("Error: {}", error), Style::default().fg(Color::Red)),
+            ]));
+        }
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(Block::default().title(title).borders(Borders::ALL))
+        .wrap(Wrap { trim: true })
+        .scroll((app.diff_scroll, 0));
+
+    f.render_widget(paragraph, area);
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -107,6 +107,13 @@ fn render_sync_help(f: &mut Frame, app: &App, area: Rect) {
             ),
             Span::raw("Dry Run"),
             Span::styled(
+                "  (R) ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Reload Config"),
+            Span::styled(
                 "  (r) ",
                 Style::default()
                     .fg(Color::Cyan)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -16,7 +16,7 @@ const MIN_PROFILE_HEIGHT: u16 = 5;
 const LOG_PERCENTAGE: u16 = 70;
 
 /// Renders the entire TUI frame.
-/// 
+///
 /// The UI is divided into three sections:
 /// 1. Help bar showing available commands
 /// 2. Profile list for selection
@@ -37,7 +37,7 @@ pub fn render(f: &mut Frame, app: &App) {
 }
 
 /// Renders the help bar showing available key bindings.
-/// 
+///
 /// Displays different content when a sync is in progress.
 fn render_help(f: &mut Frame, app: &App, area: Rect) {
     let text = if app.sync_in_progress {
@@ -113,7 +113,7 @@ fn render_profile_list(f: &mut Frame, app: &App, area: Rect) {
 }
 
 /// Renders the log output panel with auto-scrolling.
-/// 
+///
 /// The log automatically scrolls to show the most recent messages.
 fn render_log_output(f: &mut Frame, app: &App, area: Rect) {
     let text: Vec<Line> = app

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -610,19 +610,14 @@ links = [
 
     // Restore backup for real
     let restore_logs = manager.restore_backup(backup, false)?;
-    for log in &restore_logs {
-        println!("{}", log);
-    }
     assert!(restore_logs.iter().any(|s| s.contains("Restoring backup")));
     assert!(restore_logs.iter().any(|s| s.contains("RESTORE")));
 
-    // Check if it's still a symlink
-    println!("Is symlink after restore: {}", home_dir.child(".bashrc").path().is_symlink());
-    
     // Verify the old content was restored
-    let content = fs::read_to_string(home_dir.child(".bashrc").path())?;
-    println!("Content after restore: {}", content);
-    assert_eq!(content, "OLD BASHRC");
+    assert_eq!(
+        fs::read_to_string(home_dir.child(".bashrc").path())?,
+        "OLD BASHRC"
+    );
 
     // Verify backup file was removed
     assert!(!backup.backup_path.exists());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -747,3 +747,146 @@ links = [
 
     Ok(())
 }
+
+#[test]
+fn test_diff_preview() -> Result<(), Box<dyn std::error::Error>> {
+    use tui_dotfile_manager::core::diff::DiffResult;
+
+    // Setup a temporary file system
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create mock dotfiles
+    repo_dir
+        .child(".bashrc")
+        .write_str("# New bashrc\necho 'Hello from new bashrc'\n")?;
+    repo_dir
+        .child(".vimrc")
+        .write_str("set number\nset tabstop=4\n")?;
+
+    // Create mock existing files in 'home' with different content
+    home_dir
+        .child(".bashrc")
+        .write_str("# Old bashrc\necho 'Hello from old bashrc'\n")?;
+    // .vimrc doesn't exist - should show as new file
+
+    // Create the config.toml
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }},
+    {{ source = ".vimrc", target = "{}/.vimrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    // Initialize the manager
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Generate diff preview
+    let diffs = manager.preview_diff("test")?;
+
+    // Should have two diffs: one for .bashrc (modified) and one for .vimrc (new)
+    assert_eq!(diffs.len(), 2);
+
+    // Check first diff (.bashrc) - should be a FileDiff
+    match &diffs[0] {
+        DiffResult::FileDiff { diff_lines, .. } => {
+            // Should have some diff lines
+            assert!(!diff_lines.is_empty());
+        }
+        _ => panic!("Expected FileDiff for .bashrc"),
+    }
+
+    // Check second diff (.vimrc) - should be a NewFile
+    match &diffs[1] {
+        DiffResult::NewFile {
+            content_preview, ..
+        } => {
+            // Should have content preview
+            assert!(!content_preview.is_empty());
+            assert!(content_preview.iter().any(|l| l.contains("set number")));
+        }
+        _ => panic!("Expected NewFile for .vimrc"),
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_diff_preview_binary_file() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+    use tui_dotfile_manager::core::diff::DiffResult;
+
+    // Setup a temporary file system
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create directories
+    fs::create_dir_all(repo_dir.path())?;
+    fs::create_dir_all(home_dir.path())?;
+
+    // Create a binary file in repo
+    let mut file = fs::File::create(repo_dir.child("image.bin").path())?;
+    file.write_all(&[0u8, 1, 2, 3, 0, 255])?;
+    drop(file);
+
+    // Create a different binary file in home
+    let mut file = fs::File::create(home_dir.child("image.bin").path())?;
+    file.write_all(&[0u8, 5, 6, 7, 0, 255])?;
+    drop(file);
+
+    // Create the config.toml
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = "image.bin", target = "{}/image.bin" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    // Initialize the manager
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Generate diff preview
+    let diffs = manager.preview_diff("test")?;
+
+    // Should have one diff for the binary file
+    assert_eq!(diffs.len(), 1);
+
+    // Check diff - should be BinaryFile
+    match &diffs[0] {
+        DiffResult::BinaryFile { .. } => {
+            // Expected
+        }
+        _ => panic!("Expected BinaryFile for image.bin"),
+    }
+
+    Ok(())
+}
+

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -120,13 +120,13 @@ fn test_invalid_toml() -> Result<(), Box<dyn std::error::Error>> {
     let temp = assert_fs::TempDir::new()?;
     let config_path = temp.child("config.toml");
     config_path.write_str("this is not valid toml {")?;
-    
+
     let result = DotfileManager::new(config_path.path());
     assert!(result.is_err());
     if let Err(e) = result {
         assert!(e.to_string().contains("Failed to parse configuration"));
     }
-    
+
     Ok(())
 }
 
@@ -145,15 +145,15 @@ links = [
 ]
 "#;
     config_path.write_str(config_content)?;
-    
+
     let manager = DotfileManager::new(config_path.path())?;
     let result = manager.execute_sync("nonexistent", false);
-    
+
     assert!(result.is_err());
     if let Err(e) = result {
         assert!(e.to_string().contains("Profile not found"));
     }
-    
+
     Ok(())
 }
 
@@ -163,10 +163,10 @@ fn test_missing_source_file() -> Result<(), Box<dyn std::error::Error>> {
     let config_path = temp.child("config.toml");
     let repo_dir = temp.child("dotfiles");
     let home_dir = temp.child("home");
-    
+
     // Create repo but don't create the source file
     repo_dir.create_dir_all()?;
-    
+
     let config_content = format!(
         r#"
 [settings]
@@ -182,13 +182,15 @@ links = [
         home_dir.path().display()
     );
     config_path.write_str(&config_content)?;
-    
+
     let manager = DotfileManager::new(config_path.path())?;
     let logs = manager.execute_sync("test", false)?;
-    
+
     // Should warn about missing file but not fail
-    assert!(logs.iter().any(|s| s.contains("[WARN]") && s.contains("does not exist")));
-    
+    assert!(logs
+        .iter()
+        .any(|s| s.contains("[WARN]") && s.contains("does not exist")));
+
     Ok(())
 }
 
@@ -198,13 +200,13 @@ fn test_symlink_already_correct() -> Result<(), Box<dyn std::error::Error>> {
     let config_path = temp.child("config.toml");
     let repo_dir = temp.child("dotfiles");
     let home_dir = temp.child("home");
-    
+
     // Create source file
     repo_dir.child(".bashrc").write_str("REPO BASHRC")?;
-    
+
     // Create target directory
     home_dir.create_dir_all()?;
-    
+
     let config_content = format!(
         r#"
 [settings]
@@ -220,16 +222,18 @@ links = [
         home_dir.path().display()
     );
     config_path.write_str(&config_content)?;
-    
+
     let manager = DotfileManager::new(config_path.path())?;
-    
+
     // First sync creates the link
     manager.execute_sync("test", false)?;
-    
+
     // Second sync should skip (already correct)
     let logs = manager.execute_sync("test", false)?;
-    assert!(logs.iter().any(|s| s.contains("[SKIP]") && s.contains("already correct")));
-    
+    assert!(logs
+        .iter()
+        .any(|s| s.contains("[SKIP]") && s.contains("already correct")));
+
     Ok(())
 }
 
@@ -258,13 +262,13 @@ links = [
 ]
 "#;
     config_path.write_str(config_content)?;
-    
+
     let manager = DotfileManager::new(config_path.path())?;
     let profiles = manager.get_profiles();
-    
+
     // Should be sorted alphabetically
     assert_eq!(profiles, vec!["personal", "test", "work"]);
-    
+
     Ok(())
 }
 
@@ -281,12 +285,225 @@ backup_dir = "backups"
 links = []
 "#;
     config_path.write_str(config_content)?;
-    
+
     let result = DotfileManager::new(config_path.path());
     assert!(result.is_err());
     if let Err(e) = result {
         assert!(e.to_string().contains("no links"));
     }
-    
+
+    Ok(())
+}
+
+// ============================================================================
+// CLI-specific integration tests
+// ============================================================================
+
+#[test]
+fn test_cli_headless_mode_sync() -> Result<(), Box<dyn std::error::Error>> {
+    // Test executing a sync via CLI in headless mode
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create dotfiles
+    repo_dir.child(".bashrc").write_str("CLI BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.cli_test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Simulate CLI headless mode: execute_sync directly
+    let logs = manager.execute_sync("cli_test", false)?;
+
+    // Verify sync completed
+    assert!(logs.iter().any(|s| s.contains("Executing Sync")));
+    assert!(logs.iter().any(|s| s.contains("Sync Finished")));
+    assert!(home_dir.child(".bashrc").path().is_symlink());
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_headless_mode_dry_run() -> Result<(), Box<dyn std::error::Error>> {
+    // Test executing a dry run via CLI in headless mode
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create dotfiles
+    repo_dir.child(".bashrc").write_str("CLI BASHRC")?;
+    home_dir.child(".bashrc").write_str("EXISTING BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.dryrun_test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Simulate CLI headless dry-run mode
+    let logs = manager.execute_sync("dryrun_test", true)?;
+
+    // Verify dry run output
+    assert!(logs.iter().any(|s| s.contains("DRY RUN")));
+    assert!(logs
+        .iter()
+        .any(|s| s.contains("BACKUP") && s.contains("Moving existing file")));
+
+    // Verify no changes were made
+    assert_eq!(
+        fs::read_to_string(home_dir.child(".bashrc").path())?,
+        "EXISTING BASHRC"
+    );
+    assert!(!home_dir.child(".bashrc").path().is_symlink());
+    assert!(!backup_dir.exists());
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_list_profiles() -> Result<(), Box<dyn std::error::Error>> {
+    // Test listing profiles functionality
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+
+    let config_content = r#"
+[settings]
+repo_dir = "dotfiles"
+backup_dir = "backups"
+
+[profiles.alpha]
+links = [
+    { source = ".bashrc", target = "~/.bashrc" }
+]
+
+[profiles.beta]
+links = [
+    { source = ".vimrc", target = "~/.vimrc" }
+]
+
+[profiles.gamma]
+links = [
+    { source = ".zshrc", target = "~/.zshrc" }
+]
+"#;
+    config_path.write_str(config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Simulate CLI --list-profiles functionality
+    let profiles = manager.get_profiles();
+
+    // Should be sorted alphabetically
+    assert_eq!(profiles, vec!["alpha", "beta", "gamma"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_custom_config_path() -> Result<(), Box<dyn std::error::Error>> {
+    // Test using a custom config path
+    let temp = assert_fs::TempDir::new()?;
+    let custom_config_dir = temp.child("custom");
+    custom_config_dir.create_dir_all()?;
+    let config_path = custom_config_dir.child("my-config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let home_dir = temp.child("home");
+
+    // Create dotfiles
+    repo_dir
+        .child(".bashrc")
+        .write_str("CUSTOM CONFIG BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.custom]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    // Load with custom config path
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Execute sync to verify it works
+    let logs = manager.execute_sync("custom", false)?;
+
+    assert!(logs.iter().any(|s| s.contains("Executing Sync")));
+    assert!(home_dir.child(".bashrc").path().is_symlink());
+
+    Ok(())
+}
+
+#[test]
+fn test_cli_invalid_profile_error() -> Result<(), Box<dyn std::error::Error>> {
+    // Test proper error handling for invalid profile name
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+
+    let config_content = r#"
+[settings]
+repo_dir = "dotfiles"
+backup_dir = "backups"
+
+[profiles.valid]
+links = [
+    { source = ".bashrc", target = "~/.bashrc" }
+]
+"#;
+    config_path.write_str(config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Try to sync with invalid profile
+    let result = manager.execute_sync("invalid_profile", false);
+
+    assert!(result.is_err());
+    if let Err(e) = result {
+        let err_msg = e.to_string();
+        assert!(err_msg.contains("Profile not found"));
+        assert!(err_msg.contains("invalid_profile"));
+    }
+
     Ok(())
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -507,3 +507,248 @@ links = [
 
     Ok(())
 }
+
+// ============================================================================
+// Restore functionality integration tests
+// ============================================================================
+
+#[test]
+fn test_list_backups_empty() -> Result<(), Box<dyn std::error::Error>> {
+    // Test listing backups when no backups exist
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+
+    repo_dir.child(".bashrc").write_str("REPO BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+    let backups = manager.list_backups()?;
+
+    assert_eq!(backups.len(), 0);
+    Ok(())
+}
+
+#[test]
+fn test_restore_workflow() -> Result<(), Box<dyn std::error::Error>> {
+    // Test full restore workflow: sync to create backup, list backups, restore
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create dotfiles
+    repo_dir.child(".bashrc").write_str("REPO BASHRC")?;
+
+    // Create existing file that will be backed up
+    home_dir.child(".bashrc").write_str("OLD BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Execute sync to create backup
+    manager.execute_sync("test", false)?;
+
+    // Verify symlink was created
+    assert!(home_dir.child(".bashrc").path().is_symlink());
+    assert_eq!(
+        fs::read_to_string(home_dir.child(".bashrc").path())?,
+        "REPO BASHRC"
+    );
+
+    // List backups
+    let backups = manager.list_backups()?;
+    assert_eq!(backups.len(), 1);
+    
+    let backup = &backups[0];
+    assert_eq!(backup.original_name, ".bashrc");
+    assert!(backup.backup_path.exists());
+
+    // Read backup content to verify
+    let backup_content = fs::read_to_string(&backup.backup_path)?;
+    assert_eq!(backup_content, "OLD BASHRC");
+
+    // Restore backup (dry run first)
+    let dry_run_logs = manager.restore_backup(backup, true)?;
+    assert!(dry_run_logs.iter().any(|s| s.contains("DRY RUN")));
+
+    // Symlink should still exist after dry run
+    assert!(home_dir.child(".bashrc").path().is_symlink());
+
+    // Restore backup for real
+    let restore_logs = manager.restore_backup(backup, false)?;
+    for log in &restore_logs {
+        println!("{}", log);
+    }
+    assert!(restore_logs.iter().any(|s| s.contains("Restoring backup")));
+    assert!(restore_logs.iter().any(|s| s.contains("RESTORE")));
+
+    // Check if it's still a symlink
+    println!("Is symlink after restore: {}", home_dir.child(".bashrc").path().is_symlink());
+    
+    // Verify the old content was restored
+    let content = fs::read_to_string(home_dir.child(".bashrc").path())?;
+    println!("Content after restore: {}", content);
+    assert_eq!(content, "OLD BASHRC");
+
+    // Verify backup file was removed
+    assert!(!backup.backup_path.exists());
+
+    Ok(())
+}
+
+#[test]
+fn test_delete_backup() -> Result<(), Box<dyn std::error::Error>> {
+    // Test deleting a backup file
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create dotfiles
+    repo_dir.child(".bashrc").write_str("REPO BASHRC")?;
+
+    // Create existing file that will be backed up
+    home_dir.child(".bashrc").write_str("OLD BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Execute sync to create backup
+    manager.execute_sync("test", false)?;
+
+    // List backups
+    let backups = manager.list_backups()?;
+    assert_eq!(backups.len(), 1);
+    
+    let backup = &backups[0];
+    assert!(backup.backup_path.exists());
+
+    // Delete backup
+    manager.delete_backup(backup)?;
+
+    // Verify backup was deleted
+    assert!(!backup.backup_path.exists());
+
+    // List backups again - should be empty
+    let backups = manager.list_backups()?;
+    assert_eq!(backups.len(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn test_restore_backup_before_restore() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that restoring creates a backup of the current file
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create dotfiles
+    repo_dir.child(".bashrc").write_str("REPO BASHRC")?;
+
+    // Create existing file that will be backed up
+    home_dir.child(".bashrc").write_str("OLD BASHRC")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Execute sync to create backup
+    manager.execute_sync("test", false)?;
+
+    // Verify symlink was created
+    assert!(home_dir.child(".bashrc").path().is_symlink());
+
+    // Now modify the symlink target (simulate user changes)
+    fs::remove_file(home_dir.child(".bashrc").path())?;
+    home_dir.child(".bashrc").write_str("MODIFIED BASHRC")?;
+
+    // List backups - should have one from the sync
+    let backups = manager.list_backups()?;
+    assert_eq!(backups.len(), 1);
+    
+    let original_backup = &backups[0];
+
+    // Restore the original backup
+    manager.restore_backup(original_backup, false)?;
+
+    // Now there should be a new backup of "MODIFIED BASHRC"
+    let backups = manager.list_backups()?;
+    assert_eq!(backups.len(), 1);
+
+    // The current file should be the old content
+    assert_eq!(
+        fs::read_to_string(home_dir.child(".bashrc").path())?,
+        "OLD BASHRC"
+    );
+
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -592,7 +592,7 @@ links = [
     // List backups
     let backups = manager.list_backups()?;
     assert_eq!(backups.len(), 1);
-    
+
     let backup = &backups[0];
     assert_eq!(backup.original_name, ".bashrc");
     assert!(backup.backup_path.exists());
@@ -665,7 +665,7 @@ links = [
     // List backups
     let backups = manager.list_backups()?;
     assert_eq!(backups.len(), 1);
-    
+
     let backup = &backups[0];
     assert!(backup.backup_path.exists());
 
@@ -729,7 +729,7 @@ links = [
     // List backups - should have one from the sync
     let backups = manager.list_backups()?;
     assert_eq!(backups.len(), 1);
-    
+
     let original_backup = &backups[0];
 
     // Restore the original backup

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -747,3 +747,274 @@ links = [
 
     Ok(())
 }
+
+// ============================================================================
+// Configuration reload tests
+// ============================================================================
+
+#[test]
+fn test_reload_config_with_new_profile() -> Result<(), Box<dyn std::error::Error>> {
+    // Test reloading configuration with a new profile added
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial config with one profile
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    // Update config with a second profile
+    let updated_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+
+[profiles.profile2]
+links = [
+    {{ source = ".vimrc", target = "~/.vimrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&updated_config)?;
+
+    // Reload the configuration
+    manager.reload_config(config_path.path())?;
+
+    // Verify both profiles are now available
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1", "profile2"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_with_removed_profile() -> Result<(), Box<dyn std::error::Error>> {
+    // Test reloading configuration with a profile removed
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial config with two profiles
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+
+[profiles.profile2]
+links = [
+    {{ source = ".vimrc", target = "~/.vimrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1", "profile2"]);
+
+    // Update config with only one profile
+    let updated_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile2]
+links = [
+    {{ source = ".vimrc", target = "~/.vimrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&updated_config)?;
+
+    // Reload the configuration
+    manager.reload_config(config_path.path())?;
+
+    // Verify only profile2 is now available
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile2"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_invalid_toml() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that reload fails gracefully with invalid TOML
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial valid config
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    // Write invalid TOML
+    config_path.write_str("this is not valid toml {")?;
+
+    // Reload should fail
+    let result = manager.reload_config(config_path.path());
+    assert!(result.is_err());
+
+    // Original profiles should still be available (no change on error)
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_validation_error() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that reload fails gracefully with validation errors
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial valid config
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+
+    // Write config with empty profile (fails validation)
+    let invalid_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.empty]
+links = []
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&invalid_config)?;
+
+    // Reload should fail due to validation
+    let result = manager.reload_config(config_path.path());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(e.to_string().contains("no links"));
+    }
+
+    // Original profiles should still be available
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_changed_settings() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that reloading updates settings paths
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir1 = temp.child("dotfiles1");
+    let repo_dir2 = temp.child("dotfiles2");
+    let backup_dir1 = temp.child("backups1");
+    let backup_dir2 = temp.child("backups2");
+
+    // Create initial config
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir1.path().display(),
+        backup_dir1.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+
+    // Update config with different paths
+    let updated_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir2.path().display(),
+        backup_dir2.path().display()
+    );
+    config_path.write_str(&updated_config)?;
+
+    // Reload the configuration
+    manager.reload_config(config_path.path())?;
+
+    // The settings should be updated (we can't directly check private fields,
+    // but at least verify it doesn't error)
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["test"]);
+
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -859,3 +859,274 @@ links = [
 
     Ok(())
 }
+
+// ============================================================================
+// Configuration reload tests
+// ============================================================================
+
+#[test]
+fn test_reload_config_with_new_profile() -> Result<(), Box<dyn std::error::Error>> {
+    // Test reloading configuration with a new profile added
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial config with one profile
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    // Update config with a second profile
+    let updated_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+
+[profiles.profile2]
+links = [
+    {{ source = ".vimrc", target = "~/.vimrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&updated_config)?;
+
+    // Reload the configuration
+    manager.reload_config(config_path.path())?;
+
+    // Verify both profiles are now available
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1", "profile2"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_with_removed_profile() -> Result<(), Box<dyn std::error::Error>> {
+    // Test reloading configuration with a profile removed
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial config with two profiles
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+
+[profiles.profile2]
+links = [
+    {{ source = ".vimrc", target = "~/.vimrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1", "profile2"]);
+
+    // Update config with only one profile
+    let updated_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile2]
+links = [
+    {{ source = ".vimrc", target = "~/.vimrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&updated_config)?;
+
+    // Reload the configuration
+    manager.reload_config(config_path.path())?;
+
+    // Verify only profile2 is now available
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile2"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_invalid_toml() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that reload fails gracefully with invalid TOML
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial valid config
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    // Write invalid TOML
+    config_path.write_str("this is not valid toml {")?;
+
+    // Reload should fail
+    let result = manager.reload_config(config_path.path());
+    assert!(result.is_err());
+
+    // Original profiles should still be available (no change on error)
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_validation_error() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that reload fails gracefully with validation errors
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+
+    // Create initial valid config
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.profile1]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+
+    // Write config with empty profile (fails validation)
+    let invalid_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "backups"
+
+[profiles.empty]
+links = []
+"#,
+        repo_dir.path().display()
+    );
+    config_path.write_str(&invalid_config)?;
+
+    // Reload should fail due to validation
+    let result = manager.reload_config(config_path.path());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        assert!(e.to_string().contains("no links"));
+    }
+
+    // Original profiles should still be available
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["profile1"]);
+
+    Ok(())
+}
+
+#[test]
+fn test_reload_config_changed_settings() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that reloading updates settings paths
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir1 = temp.child("dotfiles1");
+    let repo_dir2 = temp.child("dotfiles2");
+    let backup_dir1 = temp.child("backups1");
+    let backup_dir2 = temp.child("backups2");
+
+    // Create initial config
+    let initial_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir1.path().display(),
+        backup_dir1.path().display()
+    );
+    config_path.write_str(&initial_config)?;
+
+    let mut manager = DotfileManager::new(config_path.path())?;
+
+    // Update config with different paths
+    let updated_config = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+"#,
+        repo_dir2.path().display(),
+        backup_dir2.path().display()
+    );
+    config_path.write_str(&updated_config)?;
+
+    // Reload the configuration
+    manager.reload_config(config_path.path())?;
+
+    // The settings should be updated (we can't directly check private fields,
+    // but at least verify it doesn't error)
+    let profiles = manager.get_profiles();
+    assert_eq!(profiles, vec!["test"]);
+
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -747,3 +747,115 @@ links = [
 
     Ok(())
 }
+
+#[test]
+fn test_sync_with_progress_callback() -> Result<(), Box<dyn std::error::Error>> {
+    // Test that progress callback is invoked correctly during sync
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+    let home_dir = temp.child("home");
+
+    // Create multiple dotfiles
+    repo_dir.child(".bashrc").write_str("REPO BASHRC")?;
+    repo_dir.child(".vimrc").write_str("REPO VIMRC")?;
+    repo_dir.child(".gitconfig").write_str("REPO GITCONFIG")?;
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.test]
+links = [
+    {{ source = ".bashrc", target = "{}/.bashrc" }},
+    {{ source = ".vimrc", target = "{}/.vimrc" }},
+    {{ source = ".gitconfig", target = "{}/.gitconfig" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display(),
+        home_dir.path().display(),
+        home_dir.path().display(),
+        home_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Track progress updates
+    use std::sync::{Arc, Mutex};
+    let progress_updates = Arc::new(Mutex::new(Vec::new()));
+    let progress_updates_clone = Arc::clone(&progress_updates);
+
+    // Execute sync with progress callback
+    let _logs = manager.execute_sync_with_progress("test", true, |current, total, file| {
+        let mut updates = progress_updates_clone.lock().unwrap();
+        updates.push((current, total, file.to_string()));
+    })?;
+
+    // Verify progress updates
+    let updates = progress_updates.lock().unwrap();
+    assert_eq!(updates.len(), 3); // Should have 3 updates for 3 files
+
+    // Check first update
+    assert_eq!(updates[0].0, 1); // current
+    assert_eq!(updates[0].1, 3); // total
+    assert!(updates[0].2.contains(".bashrc"));
+
+    // Check second update
+    assert_eq!(updates[1].0, 2);
+    assert_eq!(updates[1].1, 3);
+    assert!(updates[1].2.contains(".vimrc"));
+
+    // Check third update
+    assert_eq!(updates[2].0, 3);
+    assert_eq!(updates[2].1, 3);
+    assert!(updates[2].2.contains(".gitconfig"));
+
+    Ok(())
+}
+
+#[test]
+fn test_get_profile_link_count() -> Result<(), Box<dyn std::error::Error>> {
+    // Test the helper method for getting profile link count
+    let temp = assert_fs::TempDir::new()?;
+    let config_path = temp.child("config.toml");
+    let repo_dir = temp.child("dotfiles");
+    let backup_dir = temp.child("backups");
+
+    let config_content = format!(
+        r#"
+[settings]
+repo_dir = "{}"
+backup_dir = "{}"
+
+[profiles.small]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }}
+]
+
+[profiles.large]
+links = [
+    {{ source = ".bashrc", target = "~/.bashrc" }},
+    {{ source = ".vimrc", target = "~/.vimrc" }},
+    {{ source = ".gitconfig", target = "~/.gitconfig" }},
+    {{ source = ".zshrc", target = "~/.zshrc" }}
+]
+"#,
+        repo_dir.path().display(),
+        backup_dir.path().display()
+    );
+    config_path.write_str(&config_content)?;
+
+    let manager = DotfileManager::new(config_path.path())?;
+
+    // Test profile link counts
+    assert_eq!(manager.get_profile_link_count("small"), 1);
+    assert_eq!(manager.get_profile_link_count("large"), 4);
+    assert_eq!(manager.get_profile_link_count("nonexistent"), 0);
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces major new features and improvements to the dotfile manager, with a focus on enhanced usability, automation, and file diffing capabilities. The most significant change is the addition of a robust diff preview system, allowing users to view file differences before syncing, both in the TUI and via CLI. The update also brings comprehensive CLI argument support for headless operation, configuration reloads without restarting, and detailed documentation of all new workflows and features.

**Major Features and Enhancements:**

*Diff Preview and Comparison:*
- Added a new `src/core/diff.rs` module implementing file diff generation using the `similar` crate, with support for text, binary, new files, symlinks, and error handling. Provides structured diff results and color-coded diff lines for TUI/CLI display. Includes extensive tests.
- Updated the README to document the diff preview feature, explaining its operation, workflow, and user interface integration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R223) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R233-R257)

*CLI and Automation Improvements:*
- Added the `clap` crate for argument parsing and documented all supported CLI arguments, enabling headless operation, custom config paths, direct profile selection, dry runs, and profile listing. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R32-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R15) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R223)
- Expanded README usage sections to provide automation, scripting, CI/CD, and aliasing examples for CLI workflows.

*Configuration Reload:*
- Implemented a `reload_config` method on `DotfileManager` to reload `config.toml` at runtime, enabling TUI hot-reload and updating all internal state accordingly.
- Documented the configuration reload feature and its usage in the README, including new keybindings (`R`) for TUI reload. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R223)

*Restore and Backup Improvements:*
- Enhanced restore workflow documentation, clarifying backup discovery, preview, restoration, and deletion in the TUI. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R223) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R233-R257)
- Added a safety note that files are backed up before restoration to prevent data loss.

*Dependency and Documentation Updates:*
- Added `similar` and `clap` dependencies to `Cargo.toml` for diffing and argument parsing. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R32-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R319-R342)
- Updated the README to reflect all new features, workflows, and future enhancements, and removed outdated limitations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R223) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R233-R257) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R319-R342)

**References:** [[1]](diffhunk://#diff-96e66f4224376c0575e2a58852037a4595577c281d315c5c7c18d9914cf39325R1-R347) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R32-R35) [[3]](diffhunk://#diff-c9847c547ca0495aef85e46e1ea46d90538caffb0cc2994c2173cc630a1b63e2R79-R132) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10-R15) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L77-R223) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R233-R257) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R319-R342)